### PR TITLE
Add token-info helper script

### DIFF
--- a/app/workflow/steps/AGENTS.md
+++ b/app/workflow/steps/AGENTS.md
@@ -7,6 +7,12 @@ Below is a complete canvas of **12 steps**, each with:
 - **Execution**: prerequisites, HTTP request(s), expected responses, and behavior
 - **Required Inputs** (variables or tokens)
 
+Before running or developing a step that performs live API calls, execute
+`./scripts/token-info.sh` to confirm the Google and Microsoft bearer tokens are
+valid. The script queries Google's tokeninfo endpoint and Microsoft Graph so you
+can quickly verify access. These credentials point to test tenants, so API
+mutations are allowed during step development.
+
 ## Step 1: `verifyPrimaryDomain`
 
 ### Purpose

--- a/scripts/token-info.sh
+++ b/scripts/token-info.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/token-info.sh [GOOGLE_TOKEN_FILE] [MICROSOFT_TOKEN_FILE]
+# Defaults to ./google_bearer.token and ./microsoft_bearer.token
+
+GOOGLE_TOKEN_FILE="${1:-./google_bearer.token}"
+MS_TOKEN_FILE="${2:-./microsoft_bearer.token}"
+
+if [[ ! -f "$GOOGLE_TOKEN_FILE" ]]; then
+  echo "Google token file not found: $GOOGLE_TOKEN_FILE" >&2
+  exit 1
+fi
+if [[ ! -f "$MS_TOKEN_FILE" ]]; then
+  echo "Microsoft token file not found: $MS_TOKEN_FILE" >&2
+  exit 1
+fi
+
+GOOGLE_TOKEN=$(cat "$GOOGLE_TOKEN_FILE")
+MS_TOKEN=$(cat "$MS_TOKEN_FILE")
+
+# Query Google tokeninfo endpoint
+echo "# Google token info"
+curl -fsSL "https://oauth2.googleapis.com/tokeninfo?access_token=${GOOGLE_TOKEN}" | jq .
+
+echo
+
+# Query Microsoft Graph to fetch organization domains
+echo "# Microsoft organization"
+curl -fsSL -H "Authorization: Bearer ${MS_TOKEN}" https://graph.microsoft.com/v1.0/organization | jq .


### PR DESCRIPTION
## Summary
- add `scripts/token-info.sh` to inspect Google and Microsoft bearer tokens
- update workflow step authoring guide to mention using the helper script

## Testing
- `pnpm lint`
- `pnpm check`
- `./scripts/token-info.sh | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_684f7f5bbd5c8322b5bd9e8cca4267f3