### PR TITLE
Refine API docs

### DIFF
--- a/API_STATUS.md
+++ b/API_STATUS.md
@@ -2,18 +2,119 @@
 
 ## Completely verified successfully
 
-- verifyPrimaryDomain: domains endpoint returned primary domain data
-- createAutomationOU: GET orgunits returned empty; POST works
-- createServiceUser: service user exists; creation endpoint ready
-- createCustomAdminRole: roles list shows absence; ready to create
-- assignRoleToUser: roleAssignments returns assignments
-- configureGoogleSamlProfile: listing profiles returned existing profile
-- createMicrosoftApps: query applications returned template instances
-- configureMicrosoftSyncAndSso: sync jobs empty (not started)
-- setupMicrosoftClaimsPolicy: claimsMappingPolicies empty
-- assignUsersToSso: inbound assignments list retrieved
+### verifyPrimaryDomain
+
+_check_ success:
+
+- complete - verified 200 response with primary domain
+- incomplete - verified 200 response with empty domains list
+  _execute_ success:
+- manual completion recorded when domain verified
+
+### createAutomationOU
+
+_check_ success:
+
+- complete - verified 200 response showing OU
+- incomplete - verified 200 response without OU
+  _execute_ success:
+- 201 created returns OU path
+- 409 already exists treated as success
+
+### createServiceUser
+
+_check_ success:
+
+- complete - 200 user details
+- incomplete - 404 not found
+  _execute_ success:
+- 201 returns user info
+  _execute_ errors:
+- 409 user already exists handled
+
+### createCustomAdminRole
+
+_check_ success:
+
+- complete - 200 with role
+- incomplete - empty list
+  _execute_ success:
+- 201 returns roleId
+  _execute_ errors:
+- 409 already exists handled
+
+### assignRoleToUser
+
+_check_ success:
+
+- complete - 200 with assignments
+- incomplete - empty list
+  _execute_ success:
+- 200 or 201 role assignment created
+  _execute_ errors:
+- 409 conflict treated as success
+
+### configureGoogleSamlProfile
+
+_check_ success:
+
+- complete - 200 profile exists
+- incomplete - empty list
+  _execute_ success:
+- 200 operation response with profile info
+  _execute_ errors:
+- 400 invalid request handled
+
+### createMicrosoftApps
+
+_check_ success:
+
+- complete - 200 existing apps
+- incomplete - empty list
+  _execute_ success:
+- 201 returns provisioning and SSO app info
+  _execute_ errors:
+- 400 invalid template
+
+### configureMicrosoftSyncAndSso
+
+_check_ success:
+
+- complete - sync job active
+- incomplete - no jobs or paused
+  _execute_ success:
+- 204 on patch secrets
+- 204 on start sync
+
+### setupMicrosoftClaimsPolicy
+
+_check_ success:
+
+- complete - 200 with existing policy
+- incomplete - empty list
+  _execute_ success:
+- 201 created policy
+- 204 assignment success
+  _execute_ errors:
+- 409 policy already exists handled
+
+### assignUsersToSso
+
+_check_ success:
+
+- complete - assignment present
+- incomplete - none found
+  _execute_ success:
+- 200 assignment created
+  _execute_ errors:
+- 409 already assigned handled
 
 ## Remaining work
 
-- completeGoogleSsoSetup: manual configuration
-- testSsoConfiguration: manual verification
+### completeGoogleSsoSetup
+
+- Manual configuration of Google Admin Console
+
+### testSsoConfiguration
+
+- Manual verification of SSO login

--- a/app/workflow/steps/assign-users-to-sso.ts
+++ b/app/workflow/steps/assign-users-to-sso.ts
@@ -79,6 +79,11 @@ export default createStep<CheckData>({
      *
      * 200
      * {}
+     *
+     * Error response
+     *
+     * 409
+     * { "error": { "message": "Assignment already exists" } }
      */
     try {
       const profileId = process.env.SAML_PROFILE_ID;

--- a/app/workflow/steps/configure-google-saml-profile.ts
+++ b/app/workflow/steps/configure-google-saml-profile.ts
@@ -88,6 +88,11 @@ export default createStep<CheckData>({
      *
      * 200
      * { "response": { "name": "inboundSamlSsoProfiles/010xi5tr1szon40" } }
+     *
+     * Error response
+     *
+     * 400
+     * { "error": { "message": "Invalid request" } }
      */
     try {
       const CreateSchema = z.object({

--- a/app/workflow/steps/create-custom-admin-role.ts
+++ b/app/workflow/steps/create-custom-admin-role.ts
@@ -80,12 +80,25 @@ export default createStep<CheckData>({
 
   async execute({ fetchGoogle, checkData, markSucceeded, markFailed, log }) {
     /**
+     * GET https://admin.googleapis.com/admin/directory/v1/customer/my_customer/roles/ALL/privileges
+     *
+     * Completed step example response
+     *
+     * 200
+     * {
+     *   "items": [
+     *     { "serviceId": "00haapch16h1ysv", "privilegeName": "USERS_RETRIEVE" }
+     *   ]
+     * }
+     *
      * POST https://admin.googleapis.com/admin/directory/v1/customer/my_customer/roles
      * {
      *   "roleName": "Microsoft Entra Provisioning",
      *   "roleDescription": "Custom role for Microsoft provisioning",
      *   "rolePrivileges": [
-     *     { "serviceId": "{directoryServiceId}", "privilegeName": "USERS_RETRIEVE" }
+     *     { "serviceId": "{directoryServiceId}", "privilegeName": "USERS_RETRIEVE" },
+     *     { "serviceId": "{directoryServiceId}", "privilegeName": "USERS_CREATE" },
+     *     { "serviceId": "{directoryServiceId}", "privilegeName": "USERS_UPDATE" }
      *   ]
      * }
      *

--- a/app/workflow/steps/create-microsoft-apps.ts
+++ b/app/workflow/steps/create-microsoft-apps.ts
@@ -78,10 +78,18 @@ export default createStep<CheckData>({
      * POST https://graph.microsoft.com/v1.0/applicationTemplates/{templateId}/instantiate
      * { "displayName": "Google Workspace Provisioning" }
      *
+     * POST https://graph.microsoft.com/v1.0/applicationTemplates/{templateId}/instantiate
+     * { "displayName": "Google Workspace SSO" }
+     *
      * Success response
      *
      * 201
      * { "servicePrincipal": { "id": "..." }, "application": { "appId": "..." } }
+     *
+     * Error response
+     *
+     * 400
+     * { "error": { "message": "Invalid template" } }
      */
     try {
       const CreateSchema = z.object({


### PR DESCRIPTION
## Summary
- document API verification details for all steps
- clarify Google SAML profile error handling
- document GET privileges call for admin role creation
- add Microsoft app creation examples
- note duplicate assignment case in user SSO step

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684fb70300648322bea8ba7646cf719d