### PR TITLE
Add OAuth login UI with cookie validation

### DIFF
--- a/app/api/auth/google/callback/route.ts
+++ b/app/api/auth/google/callback/route.ts
@@ -1,0 +1,33 @@
+import { ApiEndpoint, OAuthConfig } from "@/constants";
+import { setChunkedCookie } from "@/lib/chunked-cookies";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  if (!code) {
+    return NextResponse.json({ error: "missing_code" }, { status: 400 });
+  }
+
+  const params = new URLSearchParams({
+    code,
+    client_id: OAuthConfig.Google.clientId,
+    client_secret: OAuthConfig.Google.clientSecret,
+    redirect_uri: OAuthConfig.Google.redirectUri,
+    grant_type: "authorization_code"
+  });
+
+  const res = await fetch(ApiEndpoint.GoogleAuth.Token, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString()
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    return NextResponse.json(data, { status: 400 });
+  }
+
+  const response = NextResponse.redirect(new URL("/", request.url));
+  await setChunkedCookie(response, "googleToken", data.access_token as string);
+  return response;
+}

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -1,0 +1,16 @@
+import { ApiEndpoint, OAuthConfig, OAuthScope } from "@/constants";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const params = new URLSearchParams({
+    client_id: OAuthConfig.Google.clientId,
+    redirect_uri: OAuthConfig.Google.redirectUri,
+    response_type: "code",
+    scope: OAuthScope.Google,
+    access_type: "offline",
+    prompt: "consent"
+  });
+  return NextResponse.redirect(
+    `${ApiEndpoint.GoogleAuth.Authorize}?${params.toString()}`
+  );
+}

--- a/app/api/auth/microsoft/callback/route.ts
+++ b/app/api/auth/microsoft/callback/route.ts
@@ -1,0 +1,34 @@
+import { ApiEndpoint, OAuthConfig, OAuthScope } from "@/constants";
+import { setChunkedCookie } from "@/lib/chunked-cookies";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  if (!code) {
+    return NextResponse.json({ error: "missing_code" }, { status: 400 });
+  }
+
+  const params = new URLSearchParams({
+    client_id: OAuthConfig.Microsoft.clientId,
+    client_secret: OAuthConfig.Microsoft.clientSecret,
+    code,
+    redirect_uri: OAuthConfig.Microsoft.redirectUri,
+    grant_type: "authorization_code",
+    scope: OAuthScope.Microsoft
+  });
+
+  const tokenRes = await fetch(ApiEndpoint.MicrosoftAuth.Token, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString()
+  });
+  const data = await tokenRes.json();
+  if (!tokenRes.ok) {
+    return NextResponse.json(data, { status: 400 });
+  }
+
+  const response = NextResponse.redirect(new URL("/", request.url));
+  await setChunkedCookie(response, "msToken", data.access_token as string);
+  return response;
+}

--- a/app/api/auth/microsoft/route.ts
+++ b/app/api/auth/microsoft/route.ts
@@ -1,0 +1,14 @@
+import { ApiEndpoint, OAuthConfig, OAuthScope } from "@/constants";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const params = new URLSearchParams({
+    client_id: OAuthConfig.Microsoft.clientId,
+    response_type: "code",
+    redirect_uri: OAuthConfig.Microsoft.redirectUri,
+    scope: OAuthScope.Microsoft
+  });
+  return NextResponse.redirect(
+    `${ApiEndpoint.MicrosoftAuth.Authorize}?${params.toString()}`
+  );
+}

--- a/app/api/auth/status/route.ts
+++ b/app/api/auth/status/route.ts
@@ -1,0 +1,35 @@
+import { ApiEndpoint } from "@/constants";
+import { getChunkedCookie } from "@/lib/chunked-cookies";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const googleToken = await getChunkedCookie("googleToken");
+  const msToken = await getChunkedCookie("msToken");
+  const result = { google: { valid: false }, microsoft: { valid: false } };
+
+  if (googleToken) {
+    try {
+      const res = await fetch(
+        `${ApiEndpoint.GoogleAuth.TokenInfo}?access_token=${googleToken}`
+      );
+      const data = await res.json();
+      result.google.valid =
+        res.ok && (data.scope || "").includes("admin.directory.user.readonly");
+    } catch {
+      result.google.valid = false;
+    }
+  }
+
+  if (msToken) {
+    try {
+      const res = await fetch(ApiEndpoint.Microsoft.Me, {
+        headers: { Authorization: `Bearer ${msToken}` }
+      });
+      result.microsoft.valid = res.ok;
+    } catch {
+      result.microsoft.valid = false;
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/app/components/AuthSection.tsx
+++ b/app/components/AuthSection.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Status {
+  google: { valid: boolean };
+  microsoft: { valid: boolean };
+}
+
+export default function AuthSection() {
+  const [status, setStatus] = useState<Status>();
+
+  useEffect(() => {
+    fetch("/api/auth/status")
+      .then((r) => r.json())
+      .then(setStatus)
+      .catch(() => setStatus(undefined));
+  }, []);
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold mb-2">Authentication</h2>
+      <div className="mb-2 flex items-center gap-2">
+        <a className="underline" href="/api/auth/google">
+          Sign in with Google
+        </a>
+        {status && <span>{status.google.valid ? "✅" : "❌"}</span>}
+      </div>
+      <div className="flex items-center gap-2">
+        <a className="underline" href="/api/auth/microsoft">
+          Sign in with Microsoft
+        </a>
+        {status && <span>{status.microsoft.valid ? "✅" : "❌"}</span>}
+      </div>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { StepId, StepUIState, WorkflowVars } from "@/types";
 import { useEffect, useState } from "react";
+import AuthSection from "./components/AuthSection";
 import { runStep } from "./workflow/engine";
 
 type StepStatus = StepUIState;
@@ -45,6 +46,7 @@ export default function WorkflowPage() {
 
   return (
     <main>
+      <AuthSection />
       <h1>Federation Workflow</h1>
       <ul>
         {STEP_SEQUENCE.map((id) => {

--- a/constants.ts
+++ b/constants.ts
@@ -20,6 +20,11 @@ export const ApiEndpoint = {
     SsoAssignments:
       "https://cloudidentity.googleapis.com/v1/inboundSsoAssignments"
   },
+  GoogleAuth: {
+    Authorize: "https://accounts.google.com/o/oauth2/v2/auth",
+    Token: "https://oauth2.googleapis.com/token",
+    TokenInfo: "https://oauth2.googleapis.com/tokeninfo"
+  },
 
   Microsoft: {
     Applications: "https://graph.microsoft.com/beta/applications",
@@ -43,7 +48,13 @@ export const ApiEndpoint = {
       `https://graph.microsoft.com/v1.0/servicePrincipals/${spId}/claimsMappingPolicies/$ref`,
 
     ReadClaimsPolicy: (spId: string) =>
-      `https://graph.microsoft.com/beta/servicePrincipals/${spId}/claimsMappingPolicies`
+      `https://graph.microsoft.com/beta/servicePrincipals/${spId}/claimsMappingPolicies`,
+
+    Me: "https://graph.microsoft.com/v1.0/me"
+  },
+  MicrosoftAuth: {
+    Authorize: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    Token: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
   }
 };
 
@@ -52,3 +63,22 @@ export const TemplateId = {
 };
 
 export const GroupId = { AllUsers: "allUsers" };
+
+export const OAuthScope = {
+  Google:
+    "openid https://www.googleapis.com/auth/admin.directory.user.readonly",
+  Microsoft: "https://graph.microsoft.com/.default offline_access"
+};
+
+export const OAuthConfig = {
+  Google: {
+    clientId: "dummy-google-client-id",
+    clientSecret: "dummy-google-client-secret",
+    redirectUri: "http://localhost:3000/api/auth/google/callback"
+  },
+  Microsoft: {
+    clientId: "dummy-ms-client-id",
+    clientSecret: "dummy-ms-client-secret",
+    redirectUri: "http://localhost:3000/api/auth/microsoft/callback"
+  }
+};

--- a/lib/chunked-cookies.ts
+++ b/lib/chunked-cookies.ts
@@ -1,0 +1,50 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+const CHUNK_SIZE = 3800;
+
+export async function setChunkedCookie(
+  response: NextResponse,
+  name: string,
+  value: string
+) {
+  const chunks = Math.ceil(value.length / CHUNK_SIZE);
+  for (let i = 0; i < chunks; i++) {
+    const chunk = value.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+    const cookieName = i === 0 ? name : `${name}-${i}`;
+    response.cookies.set(cookieName, chunk, { httpOnly: true, path: "/" });
+  }
+}
+
+export async function getChunkedCookie(
+  name: string
+): Promise<string | undefined> {
+  const store = await cookies();
+  const first = store.get(name);
+  if (!first) {
+    return undefined;
+  }
+  let value = first.value;
+  for (let i = 1; ; i++) {
+    const part = store.get(`${name}-${i}`);
+    if (!part) {
+      break;
+    }
+    value += part.value;
+  }
+  return value;
+}
+
+export async function clearChunkedCookie(response: NextResponse, name: string) {
+  const store = await cookies();
+  if (store.get(name)) {
+    response.cookies.delete(name);
+  }
+  for (let i = 1; ; i++) {
+    const part = store.get(`${name}-${i}`);
+    if (!part) {
+      break;
+    }
+    response.cookies.delete(`${name}-${i}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add Google and Microsoft OAuth constants and scopes
- implement chunked cookie helpers
- add API routes for Google and Microsoft OAuth flows
- include status check route for token validation
- create `AuthSection` component and render it on the main page

## Testing
- `npx prettier --write constants.ts lib/chunked-cookies.ts app/api/auth/google/route.ts app/api/auth/google/callback/route.ts app/api/auth/microsoft/route.ts app/api/auth/microsoft/callback/route.ts app/api/auth/status/route.ts app/components/AuthSection.tsx app/page.tsx`
- `npx eslint constants.ts lib/chunked-cookies.ts app/api/auth/google/route.ts app/api/auth/google/callback/route.ts app/api/auth/microsoft/route.ts app/api/auth/microsoft/callback/route.ts app/api/auth/status/route.ts app/components/AuthSection.tsx app/page.tsx`
- `pnpm exec tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684fb802d1708322b11db9455d7ee0e7