### PR TITLE
Display workflow steps with status and logs

### DIFF
--- a/app/api/auth/[provider]/route.ts
+++ b/app/api/auth/[provider]/route.ts
@@ -1,0 +1,41 @@
+import { OAUTH_STATE_COOKIE_NAME, PROVIDERS, Provider } from "@/constants";
+import { encrypt, generateState } from "@/lib/auth/crypto";
+import { generateAuthUrl } from "@/lib/auth/oauth";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const provider = url.pathname.split("/").pop() as Provider;
+
+  if (provider !== PROVIDERS.GOOGLE && provider !== PROVIDERS.MICROSOFT) {
+    return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
+  }
+
+  const state = generateState();
+  const baseUrl = url.protocol + "//" + url.host;
+  const authUrl = generateAuthUrl(provider, state, baseUrl);
+
+  const response = NextResponse.redirect(authUrl);
+  const data = { state, provider, timestamp: Date.now() };
+  const encrypted = encrypt(JSON.stringify(data));
+
+  const isProduction = process.env.NODE_ENV === "production";
+  const cookieOptions = {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 600
+  };
+
+  let cookieString = `${OAUTH_STATE_COOKIE_NAME}=${encrypted}`;
+  cookieString += `; Path=${cookieOptions.path}`;
+  cookieString += `; Max-Age=${cookieOptions.maxAge}`;
+  cookieString += `; SameSite=${cookieOptions.sameSite}`;
+  if (cookieOptions.httpOnly) cookieString += `; HttpOnly`;
+  if (cookieOptions.secure) cookieString += `; Secure`;
+
+  response.headers.append("Set-Cookie", cookieString);
+
+  return response;
+}

--- a/app/api/auth/callback/[provider]/route.ts
+++ b/app/api/auth/callback/[provider]/route.ts
@@ -1,0 +1,38 @@
+import { Provider } from "@/constants";
+import { exchangeCodeForToken } from "@/lib/auth/oauth";
+import { setToken, validateOAuthState } from "@/lib/auth/tokens";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const provider = url.pathname.split("/").pop() as Provider;
+  const searchParams = url.searchParams;
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
+  const error = searchParams.get("error");
+  const baseUrl = url.protocol + "//" + url.host;
+
+  if (error) {
+    console.error(err);
+    return NextResponse.redirect(`${baseUrl}/?error=${error}`);
+  }
+
+  if (!code || !state) {
+    return NextResponse.redirect(`${baseUrl}/?error=missing_params`);
+  }
+
+  const valid = await validateOAuthState(state, provider);
+  if (!valid) {
+    return NextResponse.redirect(`${baseUrl}/?error=invalid_state`);
+  }
+
+  try {
+    const token = await exchangeCodeForToken(provider, code, baseUrl);
+    await setToken(provider, token);
+    const response = NextResponse.redirect(`${baseUrl}/`);
+    return response;
+  } catch (err) {
+    console.error(err);
+    return NextResponse.redirect(`${baseUrl}/?error=token_exchange_failed`);
+  }
+}

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,12 @@
+import { PROVIDERS } from "@/constants";
+import { getToken } from "@/lib/auth/tokens";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const google = await getToken(PROVIDERS.GOOGLE);
+  const microsoft = await getToken(PROVIDERS.MICROSOFT);
+  return NextResponse.json({
+    googleAccessToken: google?.accessToken,
+    msGraphToken: microsoft?.accessToken
+  });
+}

--- a/app/api/auth/signout/[provider]/route.ts
+++ b/app/api/auth/signout/[provider]/route.ts
@@ -1,0 +1,12 @@
+import { Provider } from "@/constants";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const url = new URL(request.url);
+  const provider = url.pathname.split("/").pop() as Provider;
+  const cookieName = `${provider}_token`;
+  const baseUrl = url.protocol + "//" + url.host;
+  const response = NextResponse.redirect(`${baseUrl}/`);
+  response.cookies.set({ name: cookieName, value: "", maxAge: 0, path: "/" });
+  return response;
+}

--- a/app/components/ProviderLogin.tsx
+++ b/app/components/ProviderLogin.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { PROVIDERS } from "@/constants";
+import { Var, WorkflowVars } from "@/types";
+import { useCallback, useEffect, useState } from "react";
+
+interface Props {
+  onUpdate(vars: Partial<WorkflowVars>): void;
+}
+
+interface SessionTokens {
+  googleAccessToken?: string;
+  msGraphToken?: string;
+}
+
+export default function ProviderLogin({ onUpdate }: Props) {
+  const [tokens, setTokens] = useState<SessionTokens>({});
+
+  const loadTokens = useCallback(async () => {
+    const res = await fetch("/api/auth/session");
+    if (res.ok) {
+      const data = await res.json();
+      setTokens(data);
+      const vars: Partial<WorkflowVars> = {};
+      if (data.googleAccessToken)
+        vars[Var.GoogleAccessToken] = data.googleAccessToken;
+      if (data.msGraphToken) vars[Var.MsGraphToken] = data.msGraphToken;
+      if (Object.keys(vars).length) onUpdate(vars);
+    }
+  }, [onUpdate]);
+
+  useEffect(() => {
+    loadTokens();
+  }, [loadTokens]);
+
+  const signedIn = tokens.googleAccessToken || tokens.msGraphToken;
+
+  return (
+    <div className="border p-4 rounded mb-4">
+      <h2 className="font-semibold mb-2">Provider Login</h2>
+      {!signedIn && (
+        <div className="space-x-2">
+          <button
+            className="px-2 py-1 bg-blue-600 text-white rounded"
+            onClick={() =>
+              (window.location.href = `/api/auth/${PROVIDERS.GOOGLE}`)
+            }>
+            Sign in with Google
+          </button>
+          <button
+            className="px-2 py-1 bg-blue-600 text-white rounded"
+            onClick={() =>
+              (window.location.href = `/api/auth/${PROVIDERS.MICROSOFT}`)
+            }>
+            Sign in with Microsoft
+          </button>
+        </div>
+      )}
+      {signedIn && (
+        <div className="space-x-2">
+          <span className="text-sm">Signed in</span>
+          {tokens.googleAccessToken && (
+            <button
+              className="px-2 py-1 bg-gray-600 text-white rounded"
+              onClick={() =>
+                (window.location.href = `/api/auth/signout/${PROVIDERS.GOOGLE}`)
+              }>
+              Sign out Google
+            </button>
+          )}
+          {tokens.msGraphToken && (
+            <button
+              className="px-2 py-1 bg-gray-600 text-white rounded"
+              onClick={() =>
+                (window.location.href = `/api/auth/signout/${PROVIDERS.MICROSOFT}`)
+              }>
+              Sign out Microsoft
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -1,0 +1,70 @@
+"use client";
+import {
+  StepDefinition,
+  StepId,
+  StepUIState,
+  Var,
+  WorkflowVars
+} from "@/types";
+import StepLogs from "./StepLogs";
+
+interface StepCardProps {
+  definition: StepDefinition<readonly Var[], readonly Var[]>;
+  state?: StepUIState;
+  vars: Partial<WorkflowVars>;
+  executing: boolean;
+  onExecute(id: StepId): void;
+}
+
+export default function StepCard({
+  definition,
+  state,
+  vars,
+  executing,
+  onExecute
+}: StepCardProps) {
+  const missing = definition.requires.filter((v) => !vars[v]);
+
+  return (
+    <div className="border p-4 rounded mb-4">
+      <h2 className="font-semibold mb-1">{definition.id}</h2>
+      <div className="text-sm mb-1">Status: {state?.status ?? "idle"}</div>
+      <div className="text-sm mb-2">
+        {state?.summary || state?.error || state?.notes || ""}
+      </div>
+
+      <div className="mb-2">
+        <strong>Requires</strong>
+        <ul className="list-disc list-inside">
+          {definition.requires.map((v) => (
+            <li key={v}>
+              {v}: {vars[v] ? "✔" : "✗"}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mb-2">
+        <strong>Provides</strong>
+        <ul className="list-disc list-inside">
+          {definition.provides.map((v) => (
+            <li key={v}>
+              {v}: {vars[v] ? "✔" : "✗"}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {state?.status !== "complete" && (
+        <button
+          className="px-2 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
+          onClick={() => onExecute(definition.id)}
+          disabled={executing || missing.length > 0}>
+          Execute
+        </button>
+      )}
+
+      <StepLogs logs={state?.logs} />
+    </div>
+  );
+}

--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { StepLogEntry } from "@/types";
+
+interface StepLogsProps {
+  logs: StepLogEntry[] | undefined;
+}
+
+export default function StepLogs({ logs }: StepLogsProps) {
+  if (!logs || logs.length === 0) return null;
+  return (
+    <details className="mt-2">
+      <summary className="cursor-pointer">Logs</summary>
+      <ul className="text-xs space-y-1 mt-1">
+        {logs.map((l, idx) => (
+          <li key={idx}>
+            [{new Date(l.timestamp).toLocaleTimeString()}]
+            {l.level ? ` [${l.level}]` : ""} {l.message}
+            {l.data && (
+              <pre className="whitespace-pre-wrap bg-gray-100 p-1 mt-1">
+                {JSON.stringify(l.data, null, 2)}
+              </pre>
+            )}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-
 import "./globals.css";
 
 export const metadata: Metadata = { title: "Easy CEP" };

--- a/constants.ts
+++ b/constants.ts
@@ -52,3 +52,15 @@ export const TemplateId = {
 };
 
 export const GroupId = { AllUsers: "allUsers" };
+
+export const PROVIDERS = { GOOGLE: "google", MICROSOFT: "microsoft" } as const;
+
+export type Provider = (typeof PROVIDERS)[keyof typeof PROVIDERS];
+
+export const OAUTH_STATE_COOKIE_NAME = "oauth_state";
+
+export const WORKFLOW_CONSTANTS = {
+  TOKEN_COOKIE_MAX_AGE: 60 * 60 * 24 * 7,
+  OAUTH_STATE_TTL_MS: 10 * 60 * 1000,
+  TOKEN_REFRESH_BUFFER_MS: 5 * 60 * 1000
+};

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,3 @@
+export * from "./auth/crypto";
+export * from "./auth/oauth";
+export * from "./auth/tokens";

--- a/lib/auth/crypto.ts
+++ b/lib/auth/crypto.ts
@@ -1,0 +1,44 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes
+} from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const key = createHash("sha256")
+  .update(process.env.AUTH_SECRET || "secret")
+  .digest();
+
+export function encrypt(text: string): string {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const enc = Buffer.concat([cipher.update(text, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, enc]).toString("base64url");
+}
+
+export function decrypt(encoded: string): string {
+  const data = Buffer.from(encoded, "base64url");
+  const iv = data.subarray(0, IV_LENGTH);
+  const tag = data.subarray(IV_LENGTH, IV_LENGTH + 16);
+  const text = data.subarray(IV_LENGTH + 16);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const dec = Buffer.concat([decipher.update(text), decipher.final()]);
+  return dec.toString("utf8");
+}
+
+export function generateState(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function generateCodeVerifier(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export function generateCodeChallenge(verifier: string): string {
+  const hash = createHash("sha256").update(verifier).digest();
+  return hash.toString("base64url");
+}

--- a/lib/auth/oauth.ts
+++ b/lib/auth/oauth.ts
@@ -1,0 +1,119 @@
+import { Provider, PROVIDERS } from "@/constants";
+
+interface OAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  scopes: string[];
+}
+
+const googleOAuthConfig: OAuthConfig = {
+  clientId: process.env.GOOGLE_CLIENT_ID || "",
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+  redirectUri: `/api/auth/callback/google`,
+  authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenUrl: "https://oauth2.googleapis.com/token",
+  scopes: [
+    "openid",
+    "email",
+    "profile",
+    "https://www.googleapis.com/auth/admin.directory.user",
+    "https://www.googleapis.com/auth/admin.directory.orgunit",
+    "https://www.googleapis.com/auth/admin.directory.domain",
+    "https://www.googleapis.com/auth/admin.directory.rolemanagement",
+    "https://www.googleapis.com/auth/cloud-identity.inboundsso",
+    "https://www.googleapis.com/auth/siteverification",
+    "https://www.googleapis.com/auth/admin.directory.rolemanagement"
+  ]
+};
+
+const microsoftOAuthConfig: OAuthConfig = {
+  clientId: process.env.MICROSOFT_CLIENT_ID || "",
+  clientSecret: process.env.MICROSOFT_CLIENT_SECRET || "",
+  redirectUri: `/api/auth/callback/microsoft`,
+  authorizationUrl:
+    "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize",
+  tokenUrl: "https://login.microsoftonline.com/organizations/oauth2/v2.0/token",
+  scopes: [
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "User.Read",
+    "Directory.Read.All",
+    "Application.ReadWrite.All",
+    "AppRoleAssignment.ReadWrite.All",
+    "Policy.ReadWrite.ApplicationConfiguration",
+    "offline_access"
+  ]
+};
+
+function getOAuthConfig(provider: Provider): OAuthConfig {
+  return provider === PROVIDERS.GOOGLE ?
+      googleOAuthConfig
+    : microsoftOAuthConfig;
+}
+
+export interface Token {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  scope: string[];
+}
+
+export function generateAuthUrl(
+  provider: Provider,
+  state: string,
+  baseUrl: string
+): string {
+  const config = getOAuthConfig(provider);
+  const params = new URLSearchParams();
+  const redirectUri = new URL(config.redirectUri, baseUrl).toString();
+  params.set("client_id", config.clientId);
+  params.set("redirect_uri", redirectUri);
+  params.set("response_type", "code");
+  params.set("scope", config.scopes.join(" "));
+  params.set("state", state);
+  if (provider === PROVIDERS.GOOGLE) {
+    params.set("access_type", "offline");
+    params.set("prompt", "consent");
+  }
+  return `${config.authorizationUrl}?${params.toString()}`;
+}
+
+export async function exchangeCodeForToken(
+  provider: Provider,
+  code: string,
+  baseUrl: string
+): Promise<Token> {
+  const config = getOAuthConfig(provider);
+  const redirectUri = new URL(config.redirectUri, baseUrl).toString();
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    code,
+    redirect_uri: redirectUri,
+    grant_type: "authorization_code"
+  });
+
+  const res = await fetch(config.tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString()
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(`Token exchange failed: ${error}`);
+  }
+
+  const data = await res.json();
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+    scope: data.scope?.split(" ") || config.scopes
+  };
+}

--- a/lib/auth/tokens.ts
+++ b/lib/auth/tokens.ts
@@ -1,0 +1,54 @@
+import {
+  OAUTH_STATE_COOKIE_NAME,
+  Provider,
+  WORKFLOW_CONSTANTS
+} from "@/constants";
+import { cookies } from "next/headers";
+import { decrypt, encrypt } from "./crypto";
+import { Token } from "./oauth";
+
+export async function getToken(provider: Provider): Promise<Token | null> {
+  const cookieName = `${provider}_token`;
+  const cookie = (await cookies()).get(cookieName);
+  if (!cookie) return null;
+  try {
+    const data = decrypt(cookie.value);
+    return JSON.parse(data) as Token;
+  } catch {
+    return null;
+  }
+}
+
+export async function setToken(
+  provider: Provider,
+  token: Token
+): Promise<void> {
+  const encrypted = encrypt(JSON.stringify(token));
+  const cookieName = `${provider}_token`;
+  (await cookies()).set({
+    name: cookieName,
+    value: encrypted,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: WORKFLOW_CONSTANTS.TOKEN_COOKIE_MAX_AGE
+  });
+}
+
+export async function validateOAuthState(
+  state: string,
+  provider: Provider
+): Promise<boolean> {
+  const cookie = (await cookies()).get(OAUTH_STATE_COOKIE_NAME);
+  if (!cookie) return false;
+  try {
+    const data = JSON.parse(decrypt(cookie.value));
+    return (
+      data.state === state
+      && data.provider === provider
+      && Date.now() - data.timestamp < WORKFLOW_CONSTANTS.OAUTH_STATE_TTL_MS
+    );
+  } catch {
+    return false;
+  }
+}

--- a/types.ts
+++ b/types.ts
@@ -112,9 +112,17 @@ export interface StepExecuteContext<T> {
   markPending(notes: string): void;
 }
 
+export interface StepLogEntry {
+  timestamp: number;
+  message: string;
+  data?: unknown;
+  level?: LogLevel;
+}
+
 export interface StepUIState {
   status: "idle" | "checking" | "executing" | "complete" | "failed" | "pending";
   summary?: string;
   error?: string;
   notes?: string;
+  logs?: StepLogEntry[];
 }


### PR DESCRIPTION
## Summary
- add custom OAuth flow and provider login without next-auth
- show tokens with sign-in/out buttons and pass them to workflow state
- render each step in a small card including log details

## Testing
- `pnpm lint`
- `pnpm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb84ac704832281be1c37951650b3