### PR TITLE
Allow steps without CheckData

### DIFF
--- a/app/workflow/create-step.ts
+++ b/app/workflow/create-step.ts
@@ -5,7 +5,7 @@ import type {
   Var
 } from "@/types";
 
-export function createStep<TCheck>({
+export function createStep<TCheck = Record<string, never>>({
   id,
   requires,
   provides,

--- a/app/workflow/steps/AGENTS.md
+++ b/app/workflow/steps/AGENTS.md
@@ -19,8 +19,9 @@ mutations are allowed during step development.
 
 Every step MUST follow this exact pattern:
 
-1. Define interface for check data
-2. Call createStep with generic parameter
+1. (Optional) Define an interface for check data if you need to pass values from
+   `check()` to `execute()`
+2. Call `createStep` with that type when needed (otherwise rely on the default)
 3. In check: ALWAYS wrap in try-catch, ALWAYS call one of: markComplete, markIncomplete, markCheckFailed
 4. In execute: ALWAYS wrap in try-catch, ALWAYS call one of: markSucceeded, markFailed, markPending
 5. Use ApiEndpoint constants for ALL URLs
@@ -80,6 +81,9 @@ export default createStep<CheckData>({
   }
 });
 ```
+
+If no data needs to flow from `check()` to `execute()`, omit the `CheckData`
+interface and call `createStep()` without a generic type.
 
 ### Purpose
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,7 @@ const eslintConfig = [
       "workflow/no-any-in-schemas": "error",
 
       // 4. Step-specific patterns
-      "workflow/check-data-type-required": "error",
+      "workflow/check-data-type-required": "off",
       "workflow/no-state-mutations": "error"
     }
   },


### PR DESCRIPTION
## Summary
- make CheckData generic optional on `createStep`
- disable eslint rule that required explicit CheckData
- document optional CheckData pattern

## Testing
- `pnpm lint`
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_6850b46797d88322887c6619bfc398d6