### PR TITLE
Fix Google SAML operation handling

### DIFF
--- a/app/workflow/steps/AGENTS.md
+++ b/app/workflow/steps/AGENTS.md
@@ -454,8 +454,21 @@ Content-Type: application/json
 
 #### Expected Responses
 
-- `200 OK` with `operation` and `done: true`
-  → Details in `.response`
+- `200 OK` returning an [Operation](https://cloud.google.com/identity/docs/reference/rest/Shared.Types/Operation)
+  when `done: true`, profile details are under `.response`
+
+Example:
+
+```json
+{
+  "name": "operations/abc123",
+  "done": true,
+  "response": {
+    "name": "inboundSamlSsoProfiles/010xi5tr1szon40",
+    "spConfig": { "entityId": "...", "assertionConsumerServiceUri": "..." }
+  }
+}
+```
 
 Extract:
 
@@ -747,7 +760,7 @@ Content-Type: application/json
 
 #### Expected Responses
 
-- `200 OK` (operation returned)
+- `200 OK` returning an [Operation](https://cloud.google.com/identity/docs/reference/rest/Shared.Types/Operation) with `done: true`
 - `409 Conflict` (already assigned)
 
 ## Step 12: `testSsoConfiguration`


### PR DESCRIPTION
## Summary
- show the operation object in docs for `configureGoogleSamlProfile`
- mention operation return in docs for `assignUsersToSso`
- validate long‑running operation in `configure-google-saml-profile`
- validate long‑running operation in `assign-users-to-sso`

## Testing
- `pnpm lint`
- `pnpm check` *(fails: Expected 3 type arguments, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_6850b651761483229a0173e83ea967fc