### PR TITLE
Centralize workflow variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Each step performs one logical operation (e.g. creating a user or assigning a ro
 
 Place your step definition in: `./app/workflow/steps/{step-id}.ts`
 
-Use `kebab-case` for filenames. The `step-id` must match one of the values in `StepId` (see `./types.ts`).
+Use `kebab-case` for filenames. The `step-id` must match one of the values in `StepId` (see `./app/workflow/step-ids.ts`).
 
 There is an `AGENTS.md` file in `./app/workflow/steps` that will provide the API contracts you can expect.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This project defines a series of discrete, type-safe `step` files. Each step:
 
 The runtime engine orchestrates execution across steps using these declarations.
 
+Workflow variables live in `./app/workflow/variables.ts` and step identifiers
+in `./app/workflow/step-ids.ts`. These are re-exported from `types.ts` so most
+code can simply import from `@/types`.
+
 ## Steps
 
 Steps follow a two-phase pattern:

--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -1,11 +1,11 @@
 "use client";
-import { StepId, StepUIState, Var, WorkflowVars } from "@/types";
+import { StepIdValue, StepUIState, VarName, WorkflowVars } from "@/types";
 import StepLogs from "./StepLogs";
 
 export interface StepInfo {
-  id: StepId;
-  requires: readonly Var[];
-  provides: readonly Var[];
+  id: StepIdValue;
+  requires: readonly VarName[];
+  provides: readonly VarName[];
 }
 
 interface StepCardProps {
@@ -13,7 +13,7 @@ interface StepCardProps {
   state?: StepUIState;
   vars: Partial<WorkflowVars>;
   executing: boolean;
-  onExecute(id: StepId): void;
+  onExecute(id: StepIdValue): void;
 }
 
 export default function StepCard({

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { StepId, StepUIState, WorkflowVars } from "@/types";
+import { StepIdValue, StepUIState, WorkflowVars } from "@/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { checkStep, runStep } from "../workflow/engine";
 import ProviderLogin from "./ProviderLogin";
@@ -12,10 +12,10 @@ interface Props {
 
 export default function WorkflowClient({ steps }: Props) {
   const [vars, setVars] = useState<Partial<WorkflowVars>>({});
-  const [status, setStatus] = useState<Partial<Record<StepId, StepUIState>>>(
-    {}
-  );
-  const [executing, setExecuting] = useState<StepId | null>(null);
+  const [status, setStatus] = useState<
+    Partial<Record<StepIdValue, StepUIState>>
+  >({});
+  const [executing, setExecuting] = useState<StepIdValue | null>(null);
 
   const updateVars = useCallback((newVars: Partial<WorkflowVars>) => {
     const keys = Object.keys(newVars) as (keyof typeof newVars)[];
@@ -36,13 +36,13 @@ export default function WorkflowClient({ steps }: Props) {
   }, []);
 
   const updateStep = useCallback(
-    (stepId: StepId, stepState: StepUIState) =>
+    (stepId: StepIdValue, stepState: StepUIState) =>
       setStatus((prev) => ({ ...prev, [stepId]: stepState })),
     []
   );
 
   // Check steps when their required vars become available
-  const checkedSteps = useRef(new Set<StepId>());
+  const checkedSteps = useRef(new Set<StepIdValue>());
   useEffect(() => {
     (async () => {
       for (const step of steps) {
@@ -60,7 +60,7 @@ export default function WorkflowClient({ steps }: Props) {
     })();
   }, [vars, steps, updateStep, updateVars]);
 
-  async function handleExecute(id: StepId) {
+  async function handleExecute(id: StepIdValue) {
     const def = steps.find((s) => s.id === id);
     if (!def) return;
     const missing = def.requires.filter((v) => !vars[v]);

--- a/app/workflow/create-step.ts
+++ b/app/workflow/create-step.ts
@@ -16,8 +16,8 @@ import type {
   StepCheckContext,
   StepDefinition,
   StepExecuteContext,
-  StepId,
-  Var,
+  StepIdValue,
+  VarName,
   WorkflowVars
 } from "@/types";
 
@@ -33,11 +33,11 @@ import type {
  */
 export function createStep<
   D extends Partial<WorkflowVars>,
-  R extends readonly Var[] = Var[],
-  P extends readonly Var[] = Var[]
+  R extends readonly VarName[] = VarName[],
+  P extends readonly VarName[] = VarName[]
 >(args: {
   /** Unique identifier for the step */
-  id: StepId;
+  id: StepIdValue;
   /** Variables that must be present before the step may execute */
   requires: R;
   /** Variables provided when the step has executed successfully */
@@ -74,7 +74,7 @@ export function createStep<
 /**
  * Safely extract a required workflow variable, or throw if missing.
  */
-export function getVar<K extends Var>(
+export function getVar<K extends VarName>(
   vars: Partial<WorkflowVars>,
   key: K
 ): WorkflowVars[K] {

--- a/app/workflow/engine.ts
+++ b/app/workflow/engine.ts
@@ -18,7 +18,7 @@ import "server-only";
 import {
   LogLevel,
   StepCheckContext,
-  StepId,
+  StepIdValue,
   StepLogEntry,
   StepUIState,
   Var,
@@ -27,7 +27,7 @@ import {
 import { z } from "zod";
 import { getStep } from "./step-registry";
 
-async function processStep<T extends StepId>(
+async function processStep<T extends StepIdValue>(
   stepId: T,
   vars: Partial<WorkflowVars>,
   execute: boolean
@@ -188,14 +188,14 @@ async function processStep<T extends StepId>(
   return { state: currentState, newVars: finalVars };
 }
 
-export async function runStep<T extends StepId>(
+export async function runStep<T extends StepIdValue>(
   stepId: T,
   vars: Partial<WorkflowVars>
 ): Promise<{ state: StepUIState; newVars: Partial<WorkflowVars> }> {
   return processStep(stepId, vars, true);
 }
 
-export async function checkStep<T extends StepId>(
+export async function checkStep<T extends StepIdValue>(
   stepId: T,
   vars: Partial<WorkflowVars>
 ): Promise<{ state: StepUIState; newVars: Partial<WorkflowVars> }> {

--- a/app/workflow/step-ids.ts
+++ b/app/workflow/step-ids.ts
@@ -1,0 +1,20 @@
+/**
+ * Step identifiers for the workflow.
+ * The values are kebab-case for consistency.
+ */
+export const StepId = {
+  VerifyPrimaryDomain: "verify-primary-domain",
+  CreateAutomationOU: "create-automation-ou",
+  CreateServiceUser: "create-service-user",
+  CreateCustomAdminRole: "create-custom-admin-role",
+  AssignRoleToUser: "assign-role-to-user",
+  ConfigureGoogleSamlProfile: "configure-google-saml-profile",
+  CreateMicrosoftApps: "create-microsoft-apps",
+  ConfigureMicrosoftSyncAndSso: "configure-microsoft-sync-and-sso",
+  SetupMicrosoftClaimsPolicy: "setup-microsoft-claims-policy",
+  CompleteGoogleSsoSetup: "complete-google-sso-setup",
+  AssignUsersToSso: "assign-users-to-sso",
+  TestSsoConfiguration: "test-sso-configuration"
+} as const;
+
+export type StepIdValue = (typeof StepId)[keyof typeof StepId];

--- a/app/workflow/step-registry.ts
+++ b/app/workflow/step-registry.ts
@@ -6,7 +6,7 @@
  *              by `StepId`.
  */
 
-import { StepId } from "@/types";
+import { StepIdValue } from "@/types";
 import assignRoleToUser from "./steps/assign-role-to-user";
 import assignUsersToSso from "./steps/assign-users-to-sso";
 import completeGoogleSsoSetup from "./steps/complete-google-sso-setup";
@@ -39,7 +39,7 @@ export function getAllSteps() {
   return allSteps;
 }
 
-export function getStep<T extends StepId>(
+export function getStep<T extends StepIdValue>(
   id: T
 ): Extract<(typeof allSteps)[number], { id: T }> {
   const match = allSteps.find(

--- a/app/workflow/steps/create-service-user.ts
+++ b/app/workflow/steps/create-service-user.ts
@@ -11,7 +11,7 @@ interface CheckData {
 
 export default createStep<CheckData>({
   id: StepId.CreateServiceUser,
-  requires: [Var.GoogleAccessToken, Var.IsDomainVerified],
+  requires: [Var.GoogleAccessToken, Var.IsDomainVerified, Var.PrimaryDomain],
   provides: [
     Var.ProvisioningUserId,
     Var.ProvisioningUserEmail,

--- a/app/workflow/variables.ts
+++ b/app/workflow/variables.ts
@@ -1,0 +1,59 @@
+/**
+ * Single source of truth for all workflow variables.
+ * To add a new variable, just add it here.
+ */
+export const WORKFLOW_VARIABLES = {
+  // Tokens
+  googleAccessToken: "string",
+  msGraphToken: "string",
+
+  // Domain
+  primaryDomain: "string",
+  isDomainVerified: "boolean",
+
+  // Service account
+  provisioningUserId: "string",
+  provisioningUserEmail: "string",
+  generatedPassword: "string",
+
+  // Roles
+  adminRoleId: "string",
+  directoryServiceId: "string",
+
+  // Microsoft apps
+  ssoServicePrincipalId: "string",
+  provisioningServicePrincipalId: "string",
+  ssoAppId: "string",
+
+  // SAML
+  samlProfileId: "string",
+  entityId: "string",
+  acsUrl: "string",
+
+  // Policy
+  claimsPolicyId: "string"
+} as const;
+
+// Auto-generate Var enum with PascalCase keys
+function toPascalCase<S extends string>(str: S): Capitalize<S> {
+  return (str.charAt(0).toUpperCase() + str.slice(1)) as Capitalize<S>;
+}
+
+export const Var = (
+  Object.keys(WORKFLOW_VARIABLES) as Array<keyof typeof WORKFLOW_VARIABLES>
+).reduce(
+  (acc, key) => ({ ...acc, [toPascalCase(key)]: key }),
+  {} as { [K in keyof typeof WORKFLOW_VARIABLES as Capitalize<K>]: K }
+);
+
+// Auto-generate WorkflowVars type
+export type WorkflowVars = {
+  [K in keyof typeof WORKFLOW_VARIABLES]: (typeof WORKFLOW_VARIABLES)[K] extends (
+    "string"
+  ) ?
+    string
+  : boolean;
+};
+
+// Export useful types
+export type VarName = keyof typeof WORKFLOW_VARIABLES;

--- a/constants.ts
+++ b/constants.ts
@@ -1,7 +1,5 @@
 // ✅ Usage: Avoid string repetition and centralize well-known URLs, group IDs, and template constants.
 
-// app/workflow/constants.ts
-
 export const ApiEndpoint = {
   Google: {
     Domains:

--- a/types.ts
+++ b/types.ts
@@ -1,43 +1,13 @@
 import { z } from "zod";
+import type { StepIdValue } from "./app/workflow/step-ids";
+import type { VarName, WorkflowVars } from "./app/workflow/variables";
 
-export enum Var {
-  GoogleAccessToken = "googleAccessToken",
-  MsGraphToken = "msGraphToken",
-  PrimaryDomain = "primaryDomain",
-  IsDomainVerified = "isDomainVerified",
-  ProvisioningUserId = "provisioningUserId",
-  ProvisioningUserEmail = "provisioningUserEmail",
-  GeneratedPassword = "generatedPassword",
-  AdminRoleId = "adminRoleId",
-  DirectoryServiceId = "directoryServiceId",
-  SsoServicePrincipalId = "ssoServicePrincipalId",
-  ProvisioningServicePrincipalId = "provisioningServicePrincipalId",
-  SsoAppId = "ssoAppId",
-  SamlProfileId = "samlProfileId",
-  EntityId = "entityId",
-  AcsUrl = "acsUrl",
-  ClaimsPolicyId = "claimsPolicyId"
-}
+// Re-export workflow types from their new locations
+export { StepId } from "./app/workflow/step-ids";
+export { Var } from "./app/workflow/variables";
+export type { StepIdValue, VarName, WorkflowVars };
 
-export type WorkflowVars = { [K in Var]: string | boolean };
-
-// Workflow steps should use this ID as a filename
-// in ./app/workflow/steps/{filename-in-kebab-case}.ts
-export enum StepId {
-  VerifyPrimaryDomain = "verifyPrimaryDomain",
-  CreateAutomationOU = "createAutomationOU",
-  CreateServiceUser = "createServiceUser",
-  CreateCustomAdminRole = "createCustomAdminRole",
-  AssignRoleToUser = "assignRoleToUser",
-  ConfigureGoogleSamlProfile = "configureGoogleSamlProfile",
-  CreateMicrosoftApps = "createMicrosoftApps",
-  ConfigureMicrosoftSyncAndSso = "configureMicrosoftSyncAndSso",
-  SetupMicrosoftClaimsPolicy = "setupMicrosoftClaimsPolicy",
-  CompleteGoogleSsoSetup = "completeGoogleSsoSetup",
-  AssignUsersToSso = "assignUsersToSso",
-  TestSsoConfiguration = "testSsoConfiguration"
-}
-
+// Keep only the general types here
 export enum StepOutcome {
   Succeeded = "Succeeded",
   Failed = "Failed",
@@ -52,21 +22,16 @@ export enum LogLevel {
 }
 
 export interface StepDefinition<
-  R extends readonly Var[],
-  P extends readonly Var[]
+  R extends readonly VarName[],
+  P extends readonly VarName[]
 > {
-  /** Unique ID for the step */
-  id: StepId;
-
-  /** Variables that must be present before this step can run */
+  id: StepIdValue;
   requires: R;
-
-  /** Variables this step will populate if successful */
   provides: P;
 }
 
 export interface StepRunResult {
-  id: StepId;
+  id: StepIdValue;
   outcome: StepOutcome;
   summary: string;
   vars: Partial<WorkflowVars>;
@@ -84,10 +49,7 @@ export interface StepCheckContext<T> {
     init?: Omit<RequestInit, "headers">
   ): Promise<R>;
   log(level: LogLevel, message: string, data?: unknown): void;
-
-  /** Current workflow variables available to this step */
   vars: Partial<WorkflowVars>;
-
   markComplete(data: T): void;
   markIncomplete(summary: string, data: T): void;
   markCheckFailed(error: string): void;
@@ -105,12 +67,8 @@ export interface StepExecuteContext<T> {
     init?: Omit<RequestInit, "headers">
   ): Promise<R>;
   log(level: LogLevel, message: string, data?: unknown): void;
-
-  /** Current workflow variables available to this step */
   vars: Partial<WorkflowVars>;
-
   checkData: T;
-
   markSucceeded(vars: Partial<WorkflowVars>): void;
   markFailed(error: string): void;
   markPending(notes: string): void;


### PR DESCRIPTION
## Summary
- centralize variables in `app/workflow/variables.ts`
- define step identifiers in `app/workflow/step-ids.ts`
- refactor types to re-export new workflow constants
- update steps and components to use new types
- tweak ESLint rule to parse new variable file and disable slow-regex
- document the new workflow structure

## Testing
- `pnpm lint`
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68518797d95c8322aaa11646bcf90fef