### PR TITLE
Improve admin UI status and logs

### DIFF
--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -1,12 +1,32 @@
 "use client";
 import { StepIdValue, StepUIState, VarName, WorkflowVars } from "@/types";
 import StepLogs from "./StepLogs";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import {
+  DescriptionDetails,
+  DescriptionList,
+  DescriptionTerm
+} from "./ui/description-list";
+import { Heading } from "./ui/heading";
 
 export interface StepInfo {
   id: StepIdValue;
   requires: readonly VarName[];
   provides: readonly VarName[];
 }
+
+const statusColor: Record<
+  StepUIState["status"],
+  "zinc" | "sky" | "blue" | "green" | "red" | "amber"
+> = {
+  idle: "zinc",
+  checking: "sky",
+  executing: "blue",
+  complete: "green",
+  failed: "red",
+  pending: "amber"
+};
 
 interface StepCardProps {
   definition: StepInfo;
@@ -26,42 +46,59 @@ export default function StepCard({
   const missing = definition.requires.filter((v) => !vars[v]);
 
   return (
-    <div className="border p-4 rounded mb-4">
-      <h2 className="font-semibold mb-1">{definition.id}</h2>
-      <div className="text-sm mb-1">Status: {state?.status ?? "idle"}</div>
-      <div className="text-sm mb-2">
-        {state?.summary || state?.error || state?.notes || ""}
+    <div className="border p-4 rounded mb-4 space-y-3">
+      <Heading level={2}>{definition.id}</Heading>
+      <div className="text-sm flex items-center gap-2">
+        <span>Status:</span>
+        <Badge color={statusColor[state?.status ?? "idle"]}>
+          {state?.status ?? "idle"}
+        </Badge>
       </div>
+      {(state?.summary || state?.error || state?.notes) && (
+        <div className="text-sm text-zinc-700 dark:text-zinc-300">
+          {state?.summary || state?.error || state?.notes}
+        </div>
+      )}
 
-      <div className="mb-2">
-        <strong>Requires</strong>
-        <ul className="list-disc list-inside">
+      <div>
+        <Heading level={3} className="mb-1 text-sm font-semibold">
+          Requires
+        </Heading>
+        <DescriptionList>
           {definition.requires.map((v) => (
-            <li key={v}>
-              {v}: {vars[v] ? "✔" : "✗"}
-            </li>
+            <>
+              <DescriptionTerm key={`${v}-term`}>{v}</DescriptionTerm>
+              <DescriptionDetails key={`${v}-details`}>
+                {vars[v] ? "✔" : "✗"}
+              </DescriptionDetails>
+            </>
           ))}
-        </ul>
+        </DescriptionList>
       </div>
 
-      <div className="mb-2">
-        <strong>Provides</strong>
-        <ul className="list-disc list-inside">
+      <div>
+        <Heading level={3} className="mb-1 text-sm font-semibold">
+          Provides
+        </Heading>
+        <DescriptionList>
           {definition.provides.map((v) => (
-            <li key={v}>
-              {v}: {vars[v] ? "✔" : "✗"}
-            </li>
+            <>
+              <DescriptionTerm key={`${v}-term`}>{v}</DescriptionTerm>
+              <DescriptionDetails key={`${v}-details`}>
+                {vars[v] ? "✔" : "✗"}
+              </DescriptionDetails>
+            </>
           ))}
-        </ul>
+        </DescriptionList>
       </div>
 
       {state?.status !== "complete" && (
-        <button
-          className="px-2 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
+        <Button
+          color="blue"
           onClick={() => onExecute(definition.id)}
           disabled={executing || missing.length > 0}>
           Execute
-        </button>
+        </Button>
       )}
 
       <StepLogs logs={state?.logs} />

--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -1,5 +1,14 @@
 "use client";
-import { StepLogEntry } from "@/types";
+import { LogLevel, StepLogEntry } from "@/types";
+import { Badge } from "./ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "./ui/table";
 
 interface StepLogsProps {
   logs: StepLogEntry[] | undefined;
@@ -9,22 +18,50 @@ const INDENT = 2;
 
 export default function StepLogs({ logs }: StepLogsProps) {
   if (!logs || logs.length === 0) return null;
+
+  const levelColor: Record<LogLevel, Parameters<typeof Badge>[0]["color"]> = {
+    [LogLevel.Info]: "blue",
+    [LogLevel.Warn]: "amber",
+    [LogLevel.Error]: "red",
+    [LogLevel.Debug]: "zinc"
+  };
+
   return (
-    <details className="mt-2 max-h-48 overflow-scroll">
+    <details className="mt-2">
       <summary className="cursor-pointer">Logs</summary>
-      <ul className="text-xs space-y-1 mt-1">
-        {logs.map((l, idx) => (
-          <li key={idx}>
-            [{new Date(l.timestamp).toLocaleTimeString()}]
-            {l.level ? ` [${l.level}]` : ""} {l.message}
-            {l.data ?
-              <pre className="whitespace-pre-wrap bg-gray-100 p-1 mt-1">
-                {JSON.stringify(l.data, null, INDENT)}
-              </pre>
-            : null}
-          </li>
-        ))}
-      </ul>
+      <div className="mt-1 max-h-48 overflow-auto">
+        <Table bleed dense grid striped className="text-xs">
+          <TableHead>
+            <TableRow>
+              <TableHeader>Time</TableHeader>
+              <TableHeader>Level</TableHeader>
+              <TableHeader>Message</TableHeader>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {logs.map((l, idx) => (
+              <TableRow key={idx}>
+                <TableCell>
+                  {new Date(l.timestamp).toLocaleTimeString()}
+                </TableCell>
+                <TableCell>
+                  {l.level && (
+                    <Badge color={levelColor[l.level]}>{l.level}</Badge>
+                  )}
+                </TableCell>
+                <TableCell className="whitespace-pre-wrap">
+                  {l.message}
+                  {l.data !== undefined && l.data !== null && (
+                    <pre className="mt-1 rounded bg-gray-100 p-1 dark:bg-zinc-800">
+                      {JSON.stringify(l.data, null, INDENT)}
+                    </pre>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     </details>
   );
 }


### PR DESCRIPTION
## Summary
- show step status with badges
- organize variable lists in description lists
- add Tailwind UI button and headings
- present step logs in a table with colored levels

## Testing
- `pnpm lint`
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_685220686d108322a7b0cae2708fe62c