### PR TITLE
Refresh UI style

### DIFF
--- a/app/components/ProviderLogin.tsx
+++ b/app/components/ProviderLogin.tsx
@@ -62,12 +62,12 @@ export default function ProviderLogin({ onUpdate }: Props) {
   }, []);
 
   return (
-    <div className="border p-4 rounded mb-4">
-      <h2 className="font-semibold mb-2">Provider Login</h2>
-      <div className="space-x-2">
+    <div className="backdrop-blur-xl bg-white/[0.02] border border-white/[0.05] rounded-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)] mb-4 p-4 transition-all duration-200 ease-out">
+      <h2 className="font-semibold mb-2 text-white">Provider Login</h2>
+      <div className="flex flex-col sm:flex-row gap-2">
         {tokens.googleAccessToken ?
           <button
-            className="px-2 py-1 bg-gray-600 text-white rounded"
+            className="px-3 py-1.5 rounded backdrop-blur-sm bg-white/10 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all duration-200 ease-out"
             onClick={() => signOut(PROVIDERS.GOOGLE)}>
             {`Sign out Google${
               tokens.googleExpiresAt ?
@@ -76,7 +76,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
             }`}
           </button>
         : <button
-            className="px-2 py-1 bg-blue-600 text-white rounded"
+            className="px-3 py-1.5 rounded bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all duration-200 ease-out"
             onClick={() =>
               (window.location.href = `/api/auth/${PROVIDERS.GOOGLE}`)
             }>
@@ -85,7 +85,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
         }
         {tokens.msGraphToken ?
           <button
-            className="px-2 py-1 bg-gray-600 text-white rounded"
+            className="px-3 py-1.5 rounded backdrop-blur-sm bg-white/10 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all duration-200 ease-out"
             onClick={() => signOut(PROVIDERS.MICROSOFT)}>
             {`Sign out Microsoft${
               tokens.msGraphExpiresAt ?
@@ -94,7 +94,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
             }`}
           </button>
         : <button
-            className="px-2 py-1 bg-blue-600 text-white rounded"
+            className="px-3 py-1.5 rounded bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all duration-200 ease-out"
             onClick={() =>
               (window.location.href = `/api/auth/${PROVIDERS.MICROSOFT}`)
             }>

--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -3,11 +3,7 @@ import { StepIdValue, StepUIState, VarName, WorkflowVars } from "@/types";
 import StepLogs from "./StepLogs";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
-import {
-  DescriptionDetails,
-  DescriptionList,
-  DescriptionTerm
-} from "./ui/description-list";
+
 import { Heading } from "./ui/heading";
 
 export interface StepInfo {
@@ -28,6 +24,15 @@ const statusColor: Record<
   pending: "amber"
 };
 
+const indicatorColor: Record<StepUIState["status"], string> = {
+  idle: "bg-gray-700",
+  checking: "bg-blue-500 animate-pulse",
+  executing: "bg-blue-500 animate-pulse",
+  complete: "bg-green-500",
+  failed: "bg-red-500",
+  pending: "bg-amber-500"
+};
+
 interface StepCardProps {
   definition: StepInfo;
   state?: StepUIState;
@@ -46,50 +51,57 @@ export default function StepCard({
   const missing = definition.requires.filter((v) => !vars[v]);
 
   return (
-    <div className="border p-4 rounded mb-4 space-y-3">
-      <Heading level={2}>{definition.id}</Heading>
+    <div className="relative mb-4 rounded-xl p-6 backdrop-blur-xl bg-white/[0.02] border border-white/[0.05] shadow-[0_0_0_1px_rgba(255,255,255,0.03)] hover:shadow-[0_0_0_1px_rgba(255,255,255,0.08)] hover:bg-white/[0.03] transition-all duration-300 ease-out hover:scale-[1.01] space-y-3">
+      <div
+        className={`absolute left-0 top-0 bottom-0 w-[3px] rounded-l-xl ${indicatorColor[state?.status ?? "idle"]}`}></div>
+      <Heading level={2} className="text-white font-medium text-lg">
+        {definition.id}
+      </Heading>
       <div className="text-sm flex items-center gap-2">
         <span>Status:</span>
-        <Badge color={statusColor[state?.status ?? "idle"]}>
+        <Badge
+          className="px-2.5 py-0.5 rounded-full"
+          color={statusColor[state?.status ?? "idle"]}>
           {state?.status ?? "idle"}
         </Badge>
       </div>
       {(state?.summary || state?.error || state?.notes) && (
-        <div className="text-sm text-zinc-700 dark:text-zinc-300">
+        <div className="text-sm text-gray-300">
           {state?.summary || state?.error || state?.notes}
         </div>
       )}
 
-      <div>
-        <Heading level={3} className="mb-1 text-sm font-semibold">
-          Requires
-        </Heading>
-        <DescriptionList>
-          {definition.requires.map((v) => (
-            <>
-              <DescriptionTerm key={`${v}-term`}>{v}</DescriptionTerm>
-              <DescriptionDetails key={`${v}-details`}>
-                {vars[v] ? "✔" : "✗"}
-              </DescriptionDetails>
-            </>
-          ))}
-        </DescriptionList>
-      </div>
-
-      <div>
-        <Heading level={3} className="mb-1 text-sm font-semibold">
-          Provides
-        </Heading>
-        <DescriptionList>
-          {definition.provides.map((v) => (
-            <>
-              <DescriptionTerm key={`${v}-term`}>{v}</DescriptionTerm>
-              <DescriptionDetails key={`${v}-details`}>
-                {vars[v] ? "✔" : "✗"}
-              </DescriptionDetails>
-            </>
-          ))}
-        </DescriptionList>
+      <div className="grid grid-cols-2 gap-6 mt-4">
+        <div className="bg-black/20 rounded-lg p-4 border border-white/[0.05]">
+          <Heading level={3} className="mb-2 text-sm font-medium text-gray-400">
+            Requires
+          </Heading>
+          <ul className="space-y-1 text-sm text-gray-300">
+            {definition.requires.map((v) => (
+              <li key={v} className="flex justify-between">
+                <span className="font-mono">{v}</span>
+                <span className={vars[v] ? "text-green-400" : "text-gray-600"}>
+                  ✓
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="bg-black/20 rounded-lg p-4 border border-white/[0.05]">
+          <Heading level={3} className="mb-2 text-sm font-medium text-gray-400">
+            Provides
+          </Heading>
+          <ul className="space-y-1 text-sm text-gray-300">
+            {definition.provides.map((v) => (
+              <li key={v} className="flex justify-between">
+                <span className="font-mono">{v}</span>
+                <span className={vars[v] ? "text-green-400" : "text-gray-600"}>
+                  ✓
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
 
       {state?.status !== "complete" && (

--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -1,5 +1,9 @@
 "use client";
 import { LogLevel, StepLogEntry } from "@/types";
+import { Disclosure } from "@headlessui/react";
+import { ChevronDownIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
+import { AnimatePresence, motion } from "framer-motion";
 import { Badge } from "./ui/badge";
 import {
   Table,
@@ -27,41 +31,69 @@ export default function StepLogs({ logs }: StepLogsProps) {
   };
 
   return (
-    <details className="mt-2">
-      <summary className="cursor-pointer">Logs</summary>
-      <div className="mt-1 max-h-48 overflow-auto">
-        <Table bleed dense grid striped className="text-xs">
-          <TableHead>
-            <TableRow>
-              <TableHeader>Time</TableHeader>
-              <TableHeader>Level</TableHeader>
-              <TableHeader>Message</TableHeader>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {logs.map((l, idx) => (
-              <TableRow key={idx}>
-                <TableCell>
-                  {new Date(l.timestamp).toLocaleTimeString()}
-                </TableCell>
-                <TableCell>
-                  {l.level && (
-                    <Badge color={levelColor[l.level]}>{l.level}</Badge>
-                  )}
-                </TableCell>
-                <TableCell className="whitespace-pre-wrap">
-                  {l.message}
-                  {l.data !== undefined && l.data !== null && (
-                    <pre className="mt-1 rounded bg-gray-100 p-1 dark:bg-zinc-800">
-                      {JSON.stringify(l.data, null, INDENT)}
-                    </pre>
-                  )}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-    </details>
+    <Disclosure>
+      {({ open }) => (
+        <div className="mt-2">
+          <Disclosure.Button className="flex items-center gap-1 bg-white/5 hover:bg-white/10 rounded-lg px-3 py-1.5 text-sm transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500/50">
+            <ChevronDownIcon
+              className={clsx(
+                "h-4 w-4 transition-transform",
+                open && "rotate-180"
+              )}
+            />
+            Logs
+          </Disclosure.Button>
+          <AnimatePresence initial={false}>
+            {open && (
+              <Disclosure.Panel
+                static
+                as={motion.div}
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}>
+                <div className="mt-2 max-h-48 overflow-auto bg-black/30 rounded-lg overflow-hidden">
+                  <Table bleed dense className="text-xs">
+                    <TableHead>
+                      <TableRow>
+                        <TableHeader>Time</TableHeader>
+                        <TableHeader>Level</TableHeader>
+                        <TableHeader>Message</TableHeader>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {logs.map((l, idx) => (
+                        <TableRow key={idx} className="even:bg-white/[0.02]">
+                          <TableCell className="text-xs text-gray-500">
+                            {new Date(l.timestamp).toLocaleTimeString()}
+                          </TableCell>
+                          <TableCell>
+                            {l.level && (
+                              <Badge
+                                className="px-1.5 py-0.5 text-xs"
+                                color={levelColor[l.level]}>
+                                {l.level}
+                              </Badge>
+                            )}
+                          </TableCell>
+                          <TableCell className="whitespace-pre-wrap">
+                            {l.message}
+                            {l.data !== undefined && l.data !== null && (
+                              <pre className="mt-1 rounded bg-gray-100 p-1 dark:bg-zinc-800">
+                                {JSON.stringify(l.data, null, INDENT)}
+                              </pre>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </Disclosure.Panel>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
+    </Disclosure>
   );
 }

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -85,18 +85,25 @@ export default function WorkflowClient({ steps }: Props) {
   }
 
   return (
-    <main className="p-4">
-      <ProviderLogin onUpdate={updateVars} />
-      {steps.map((step) => (
-        <StepCard
-          key={step.id}
-          definition={step}
-          state={status[step.id]}
-          vars={vars}
-          executing={executing !== null}
-          onExecute={handleExecute}
-        />
-      ))}
+    <main className="min-h-screen bg-zinc-950 bg-gradient-to-br from-zinc-950 via-zinc-900 to-zinc-950">
+      <header className="sticky top-0 z-10 backdrop-blur-xl bg-zinc-950/80 border-b border-white/[0.08] shadow-[0_1px_3px_rgba(0,0,0,0.3)]">
+        <div className="max-w-7xl mx-auto px-6 py-3">
+          <h1 className="text-white text-sm font-medium">Easy CEP</h1>
+        </div>
+      </header>
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        <ProviderLogin onUpdate={updateVars} />
+        {steps.map((step) => (
+          <StepCard
+            key={step.id}
+            definition={step}
+            state={status[step.id]}
+            vars={vars}
+            executing={executing !== null}
+            onExecute={handleExecute}
+          />
+        ))}
+      </div>
     </main>
   );
 }

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -12,8 +12,9 @@ const styles = {
     "px-[calc(--spacing(3.5)-1px)] py-[calc(--spacing(2.5)-1px)] sm:px-[calc(--spacing(3)-1px)] sm:py-[calc(--spacing(1.5)-1px)] sm:text-sm/6",
     // Focus
     "focus:not-data-focus:outline-hidden data-focus:outline-2 data-focus:outline-offset-2 data-focus:outline-blue-500",
+    "transition-transform duration-200 ease-out active:scale-95",
     // Disabled
-    "data-disabled:opacity-50",
+    "data-disabled:opacity-40 data-disabled:cursor-not-allowed",
     // Icon
     "*:data-[slot=icon]:-mx-0.5 *:data-[slot=icon]:my-0.5 *:data-[slot=icon]:size-5 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:self-center *:data-[slot=icon]:text-(--btn-icon) sm:*:data-[slot=icon]:my-1 sm:*:data-[slot=icon]:size-4 forced-colors:[--btn-icon:ButtonText] forced-colors:data-hover:[--btn-icon:ButtonText]"
   ],
@@ -133,8 +134,8 @@ const styles = {
       "[--btn-icon:var(--color-white)]/60 data-active:[--btn-icon:var(--color-white)]/80 data-hover:[--btn-icon:var(--color-white)]/80"
     ],
     blue: [
-      "text-white [--btn-hover-overlay:var(--color-white)]/10 [--btn-bg:var(--color-blue-600)] [--btn-border:var(--color-blue-700)]/90",
-      "[--btn-icon:var(--color-blue-400)] data-active:[--btn-icon:var(--color-blue-300)] data-hover:[--btn-icon:var(--color-blue-300)]"
+      "text-white font-medium bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 active:scale-[0.98] shadow-[0_1px_0_0_rgba(255,255,255,0.1)_inset]",
+      "[--btn-icon:var(--color-blue-400)]"
     ],
     violet: [
       "text-white [--btn-hover-overlay:var(--color-white)]/10 [--btn-bg:var(--color-violet-500)] [--btn-border:var(--color-violet-600)]/90",

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,28 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
+
+  --gray-50: #f9fafb;
+  --gray-100: #f3f4f6;
+  --gray-200: #e5e7eb;
+  --gray-300: #d1d5db;
+  --gray-400: #9ca3af;
+  --gray-500: #6b7280;
+  --gray-600: #4b5563;
+  --gray-700: #374151;
+  --gray-800: #27272a;
+  --gray-900: #18181b;
+
+  --blue-500: #3b82f6;
+  --green-500: #10b981;
+  --amber-500: #f59e0b;
+
+  --surface-elevated: #18181b;
+  --surface-overlay: #27272a;
+
+  --border-subtle: rgba(255, 255, 255, 0.08);
 }
 
 @theme inline {
@@ -10,15 +30,19 @@
   --color-foreground: var(--foreground);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family:
+    Inter,
+    "SF Pro Text",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
+  scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Summary
- overhaul global color palette and fonts
- add sticky page header and gradient background
- redesign provider login with glassmorphism
- restyle workflow cards with status indicator and hover effects
- modernize log view with collapsible animation
- update button component for gradient style

## Testing
- `pnpm lint` *(fails: Unexpected any / hardcoded password)*
- `pnpm format`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685223d3d7e88322832509e1a9d84506