### PR TITLE
Handle missing bearer tokens in E2E tests

### DIFF
--- a/test/e2e/workflow.test.ts
+++ b/test/e2e/workflow.test.ts
@@ -3,6 +3,20 @@ import { StepId, Var } from '@/types';
 import fs from 'fs';
 import path from 'path';
 
+const googleTokenPath = path.join(__dirname, 'google.token');
+if (!process.env.GOOGLE_BEARER_TOKEN && fs.existsSync(googleTokenPath)) {
+  process.env.GOOGLE_BEARER_TOKEN = fs.readFileSync(googleTokenPath, 'utf8').trim();
+}
+
+const msTokenPath = '/.microsoft.token';
+if (!process.env.MS_BEARER_TOKEN && fs.existsSync(msTokenPath)) {
+  process.env.MS_BEARER_TOKEN = fs.readFileSync(msTokenPath, 'utf8').trim();
+}
+
+if (!process.env.GOOGLE_BEARER_TOKEN || !process.env.MS_BEARER_TOKEN) {
+  test.skip('E2E tests require GOOGLE_BEARER_TOKEN and MS_BEARER_TOKEN', () => {});
+} else {
+
 describe('Workflow Live E2E', () => {
   const baseVars = {
     [Var.GoogleAccessToken]: process.env.GOOGLE_BEARER_TOKEN!,
@@ -52,3 +66,5 @@ describe('Workflow Live E2E', () => {
     });
   }
 });
+
+}


### PR DESCRIPTION
## Summary
- detect bearer token environment variables at the start of e2e tests
- skip all workflow e2e tests when tokens aren't provided

## Testing
- `npx jest test/e2e/workflow.test.ts --runInBand`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685224fd2e34832287cdd0c5e8073964