### PR TITLE
Fix StepLogs color prop type

### DIFF
--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -20,12 +20,35 @@ interface StepLogsProps {
 export default function StepLogs({ logs }: StepLogsProps) {
   if (!logs || logs.length === 0) return null;
 
-  const levelColor: Record<LogLevel, string> = {
-    [LogLevel.Info]: "border-blue-500",
-    [LogLevel.Warn]: "border-amber-500",
-    [LogLevel.Error]: "border-red-500",
-    [LogLevel.Debug]: "border-gray-400"
+  const levelColor: Record<
+    LogLevel,
+    | "zinc"
+    | "indigo"
+    | "cyan"
+    | "red"
+    | "orange"
+    | "amber"
+    | "yellow"
+    | "lime"
+    | "green"
+    | "emerald"
+    | "teal"
+    | "sky"
+    | "blue"
+    | "violet"
+    | "purple"
+    | "fuchsia"
+    | "pink"
+    | "rose"
+    | undefined
+  > = {
+    [LogLevel.Info]: "blue",
+    [LogLevel.Warn]: "amber",
+    [LogLevel.Error]: "red",
+    [LogLevel.Debug]: "zinc"
   };
+
+  const INDENT = 2;
 
   return (
     <Disclosure>


### PR DESCRIPTION
## Summary
- fix StepLogs color to use Badge color names
- define missing INDENT constant

## Testing
- `pnpm test`
- `pnpm check`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68523afd00b08322a5db1b7aa49227ee