### PR TITLE
Improve workflow logging UI

### DIFF
--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -57,10 +57,17 @@ export default function StepCard({
 }: StepCardProps) {
   const missing = definition.requires.filter((v) => !vars[v]);
   const status = state?.status ?? "idle";
+  const inProgress =
+    status === "checking" || status === "executing" || status === "pending";
 
   return (
     <div
       className={`relative mb-6 rounded-xl border ${accent[status]} border-l-4 bg-white p-6 shadow-sm hover:shadow-md transition-shadow duration-200`}>
+      {inProgress && (
+        <div className="absolute left-0 right-0 top-0 h-1 overflow-hidden rounded-t">
+          <div className="animate-indeterminate h-full w-1/2 bg-blue-500" />
+        </div>
+      )}
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-2">
           <span className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-xs font-medium text-gray-700">

--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -4,14 +4,6 @@ import { Disclosure } from "@headlessui/react";
 import { ChevronDownIcon as ChevronDown } from "@heroicons/react/24/outline";
 import { AnimatePresence, motion } from "framer-motion";
 import { Badge } from "./ui/badge";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from "./ui/table";
 
 interface StepLogsProps {
   logs: StepLogEntry[] | undefined;
@@ -58,32 +50,27 @@ export default function StepLogs({ logs }: StepLogsProps) {
             <ChevronDown
               className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
             />
-            View logs
+            View logs ({logs.length})
           </Disclosure.Button>
           <AnimatePresence initial={false}>
             {open && (
               <Disclosure.Panel static>
-                <motion.div
+                <motion.ul
                   initial={{ height: 0, opacity: 0 }}
                   animate={{ height: "auto", opacity: 1 }}
                   exit={{ height: 0, opacity: 0 }}
                   transition={{ duration: 0.2 }}
-                  className="mt-2 max-h-48 overflow-auto bg-black/30 rounded-lg overflow-hidden">
-                  <Table bleed dense className="text-xs">
-                    <TableHead>
-                      <TableRow>
-                        <TableHeader>Time</TableHeader>
-                        <TableHeader>Level</TableHeader>
-                        <TableHeader>Message</TableHeader>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {logs.map((l, idx) => (
-                        <TableRow key={idx} className="even:bg-white/[0.02]">
-                          <TableCell className="text-xs text-gray-500">
-                            {new Date(l.timestamp).toLocaleTimeString()}
-                          </TableCell>
-                          <TableCell>
+                  className="mt-2 max-h-96 space-y-2 overflow-auto">
+                  {logs.map((l, idx) => (
+                    <li
+                      key={idx}
+                      className="rounded-lg border border-gray-200 bg-gray-50 p-2 text-xs">
+                      <details className="group open:pb-2">
+                        <summary className="flex cursor-pointer items-center justify-between gap-2">
+                          <span className="flex items-center gap-2">
+                            <span className="text-gray-500">
+                              {new Date(l.timestamp).toLocaleTimeString()}
+                            </span>
                             {l.level && (
                               <Badge
                                 className="px-1.5 py-0.5 text-xs"
@@ -91,20 +78,20 @@ export default function StepLogs({ logs }: StepLogsProps) {
                                 {l.level}
                               </Badge>
                             )}
-                          </TableCell>
-                          <TableCell className="whitespace-pre-wrap">
+                          </span>
+                          <span className="flex-1 truncate text-left">
                             {l.message}
-                            {l.data !== undefined && l.data !== null && (
-                              <pre className="mt-1 rounded bg-gray-100 p-1 dark:bg-zinc-800">
-                                {JSON.stringify(l.data, null, INDENT)}
-                              </pre>
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </motion.div>
+                          </span>
+                        </summary>
+                        {l.data !== undefined && l.data !== null && (
+                          <pre className="mt-2 whitespace-pre-wrap rounded bg-white p-2 dark:bg-zinc-800">
+                            {JSON.stringify(l.data, null, INDENT)}
+                          </pre>
+                        )}
+                      </details>
+                    </li>
+                  ))}
+                </motion.ul>
               </Disclosure.Panel>
             )}
           </AnimatePresence>

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -12,7 +12,7 @@ import {
   SidebarItem,
   SidebarSection
 } from "./ui/sidebar";
-import { SidebarLayout } from "./ui/sidebar-layout";
+import { StackedLayout } from "./ui/stacked-layout";
 
 interface Props {
   steps: ReadonlyArray<StepInfo>;
@@ -116,7 +116,7 @@ export default function WorkflowClient({ steps }: Props) {
   );
 
   return (
-    <SidebarLayout navbar={navbar} sidebar={sidebar}>
+    <StackedLayout navbar={navbar} sidebar={sidebar}>
       <h1 className="mb-8 text-2xl font-bold text-gray-900">Workflow</h1>
       <p className="mb-6 text-gray-600">
         Run each step to configure the environment.
@@ -136,6 +136,6 @@ export default function WorkflowClient({ steps }: Props) {
           onExecute={handleExecute}
         />
       ))}
-    </SidebarLayout>
+    </StackedLayout>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,3 +45,18 @@
     @apply text-xs text-gray-500;
   }
 }
+
+@layer utilities {
+  @keyframes indeterminate {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  .animate-indeterminate {
+    animation: indeterminate 1.5s linear infinite;
+  }
+}


### PR DESCRIPTION
## Summary
- reformat logs to expand per entry and count items
- add indeterminate progress bar on running steps
- switch workflow layout to stacked layout with top nav
- define `animate-indeterminate` utility for progress animation

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6852df1953f48322b8d9e8ef60ba9dc0