### PR TITLE
Add vars inspector & re-execute

### DIFF
--- a/app/components/ProviderLogin.tsx
+++ b/app/components/ProviderLogin.tsx
@@ -69,10 +69,18 @@ export default function ProviderLogin({ onUpdate }: Props) {
       </h2>
       <div className="flex flex-col gap-3 sm:flex-row">
         {tokens.googleAccessToken ?
-          <Button color="zinc" onClick={() => signOut(PROVIDERS.GOOGLE)}>
-            <span>G</span>
-            {`Sign out Google`}
-          </Button>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="font-medium">
+              {`Logged in to Google • ${Math.round(
+                ((tokens.googleExpiresAt ?? 0) - Date.now()) / 60000
+              )}m left`}
+            </span>
+            <button
+              className="text-blue-700 hover:underline"
+              onClick={() => signOut(PROVIDERS.GOOGLE)}>
+              Log Out
+            </button>
+          </div>
         : <Button
             color="blue"
             onClick={() =>
@@ -83,10 +91,18 @@ export default function ProviderLogin({ onUpdate }: Props) {
           </Button>
         }
         {tokens.msGraphToken ?
-          <Button color="zinc" onClick={() => signOut(PROVIDERS.MICROSOFT)}>
-            <span>M</span>
-            {`Sign out Microsoft`}
-          </Button>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="font-medium">
+              {`Logged in to Microsoft • ${Math.round(
+                ((tokens.msGraphExpiresAt ?? 0) - Date.now()) / 60000
+              )}m left`}
+            </span>
+            <button
+              className="text-blue-700 hover:underline"
+              onClick={() => signOut(PROVIDERS.MICROSOFT)}>
+              Log Out
+            </button>
+          </div>
         : <Button
             color="blue"
             onClick={() =>

--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -123,15 +123,23 @@ export default function StepCard({
         </div>
       </div>
 
-      {status !== "complete" && (
+      <div className="mt-4 flex items-center gap-2">
         <Button
           color="blue"
-          className="mt-4 inline-flex items-center gap-2"
+          className="inline-flex items-center gap-2"
           onClick={() => onExecute(definition.id)}
           disabled={executing || missing.length > 0}>
           Execute <ArrowRight className="h-4 w-4" />
         </Button>
-      )}
+        {status === "complete" && (
+          <button
+            className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
+            onClick={() => onExecute(definition.id)}
+            disabled={executing || missing.length > 0}>
+            Re-execute
+          </button>
+        )}
+      </div>
 
       <StepLogs logs={state?.logs} />
     </div>

--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -1,0 +1,111 @@
+"use client";
+import {
+  VarName,
+  WORKFLOW_VARIABLES,
+  WorkflowVars
+} from "@/app/workflow/variables";
+import { useState } from "react";
+import { Button } from "./ui/button";
+import {
+  DescriptionDetails,
+  DescriptionList,
+  DescriptionTerm
+} from "./ui/description-list";
+import { Input } from "./ui/input";
+
+interface Props {
+  vars: Partial<WorkflowVars>;
+  onChange(vars: Partial<WorkflowVars>): void;
+}
+
+export default function VarsInspector({ vars, onChange }: Props) {
+  const entries = Object.keys(WORKFLOW_VARIABLES) as VarName[];
+  return (
+    <div className="rounded-xl border border-zinc-200 p-4 bg-white shadow-sm">
+      <h2 className="mb-4 text-lg font-semibold text-gray-900">Variables</h2>
+      <DescriptionList className="text-sm">
+        {entries.map((name) => (
+          <VarItem
+            key={name}
+            name={name}
+            type={WORKFLOW_VARIABLES[name]}
+            value={vars[name]}
+            onSave={(val) => onChange({ [name]: val })}
+          />
+        ))}
+      </DescriptionList>
+    </div>
+  );
+}
+
+function VarItem({
+  name,
+  type,
+  value,
+  onSave
+}: {
+  name: VarName;
+  type: "string" | "boolean";
+  value: unknown;
+  onSave(value: unknown): void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [local, setLocal] = useState(value ?? "");
+
+  const display = value === undefined || value === null ? "" : String(value);
+  const truncated = display.length > 20 ? display.slice(0, 20) + "…" : display;
+
+  const startEdit = () => {
+    setLocal(display);
+    setEditing(true);
+  };
+
+  const handleSave = () => {
+    let val: unknown = local;
+    if (type === "boolean") {
+      val = local === "true" || local === true;
+    }
+    onSave(val as Partial<WorkflowVars>[typeof name]);
+    setEditing(false);
+  };
+
+  return (
+    <>
+      <DescriptionTerm className="whitespace-nowrap font-mono">
+        {name}
+      </DescriptionTerm>
+      <DescriptionDetails>
+        {editing ?
+          <div className="flex items-center gap-2">
+            {type === "boolean" ?
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={local === true || local === "true"}
+                onChange={(e) => setLocal(e.target.checked ? "true" : "false")}
+              />
+            : <Input
+                value={String(local)}
+                onChange={(e) => setLocal(e.target.value)}
+              />
+            }
+            <Button color="blue" size="sm" onClick={handleSave}>
+              Save
+            </Button>
+            <Button color="zinc" size="sm" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+          </div>
+        : <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-gray-700">{truncated}</span>
+            <button
+              className="text-blue-700 hover:underline text-xs"
+              onClick={startEdit}>
+              Edit
+            </button>
+          </div>
+        }
+      </DescriptionDetails>
+    </>
+  );
+}

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { StepIdValue, StepUIState, WorkflowVars } from "@/types";
+import { StepIdValue, StepUIState, Var, WorkflowVars } from "@/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { checkStep, runStep } from "../workflow/engine";
 import ProviderLogin from "./ProviderLogin";
 import StepCard, { StepInfo } from "./StepCard";
+import VarsInspector from "./VarsInspector";
 import { Navbar, NavbarLabel, NavbarSection } from "./ui/navbar";
 import {
   Sidebar,
@@ -19,7 +20,10 @@ interface Props {
 }
 
 export default function WorkflowClient({ steps }: Props) {
-  const [vars, setVars] = useState<Partial<WorkflowVars>>({});
+  const defaultPassword = useRef(Math.random().toString(36).slice(-12));
+  const [vars, setVars] = useState<Partial<WorkflowVars>>({
+    [Var.GeneratedPassword]: defaultPassword.current
+  });
   const [status, setStatus] = useState<
     Partial<Record<StepIdValue, StepUIState>>
   >({});
@@ -41,6 +45,7 @@ export default function WorkflowClient({ steps }: Props) {
       }
       return { ...prev, ...newVars };
     });
+    checkedSteps.current.clear();
   }, []);
 
   const updateStep = useCallback(
@@ -124,18 +129,25 @@ export default function WorkflowClient({ steps }: Props) {
       <div className="mb-4 text-sm text-gray-600">
         {completed} of {steps.length} steps complete
       </div>
-      <ProviderLogin onUpdate={updateVars} />
-      {steps.map((step, idx) => (
-        <StepCard
-          key={step.id}
-          index={idx}
-          definition={step}
-          state={status[step.id]}
-          vars={vars}
-          executing={executing !== null}
-          onExecute={handleExecute}
-        />
-      ))}
+      <div className="lg:flex lg:items-start lg:gap-6">
+        <div className="flex-1">
+          <ProviderLogin onUpdate={updateVars} />
+          {steps.map((step, idx) => (
+            <StepCard
+              key={step.id}
+              index={idx}
+              definition={step}
+              state={status[step.id]}
+              vars={vars}
+              executing={executing !== null}
+              onExecute={handleExecute}
+            />
+          ))}
+        </div>
+        <div className="mt-6 lg:mt-0 lg:w-80 lg:flex-none lg:sticky lg:top-4">
+          <VarsInspector vars={vars} onChange={updateVars} />
+        </div>
+      </div>
     </StackedLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add variable inspector panel
- generate default password once per page load
- allow manual editing of vars with save/cancel
- allow re-executing completed steps
- tweak login info display

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e3e77aac83228db9b8db192b5e8c