### PR TITLE
Refined UI for login, variables, and logs

### DIFF
--- a/app/components/ProviderLogin.tsx
+++ b/app/components/ProviderLogin.tsx
@@ -2,6 +2,7 @@
 import { PROVIDERS, type Provider } from "@/constants";
 import { Var, WorkflowVars } from "@/types";
 import { useCallback, useEffect, useState } from "react";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
 interface Props {
@@ -69,46 +70,96 @@ export default function ProviderLogin({ onUpdate }: Props) {
       </h2>
       <div className="flex flex-col gap-3 sm:flex-row">
         {tokens.googleAccessToken ?
-          <div className="flex items-center gap-2 text-sm">
-            <span className="font-medium">
-              {`Logged in to Google • ${Math.round(
-                ((tokens.googleExpiresAt ?? 0) - Date.now()) / 60000
-              )}m left`}
+          <div className="flex items-center gap-3">
+            <Badge color="green" className="px-3 py-1.5">
+              <svg
+                className="mr-1.5 h-3 w-3"
+                fill="currentColor"
+                viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              Google
+            </Badge>
+            <span className="text-sm text-zinc-600">
+              {Math.round(((tokens.googleExpiresAt ?? 0) - Date.now()) / 60000)}
+              m remaining
             </span>
-            <button
-              className="text-blue-700 hover:underline"
+            <Button
+              plain
+              className="text-sm"
               onClick={() => signOut(PROVIDERS.GOOGLE)}>
-              Log Out
-            </button>
+              Sign Out
+            </Button>
           </div>
         : <Button
             color="blue"
             onClick={() =>
               (window.location.href = `/api/auth/${PROVIDERS.GOOGLE}`)
             }>
-            <span>G</span>
+            <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="currentColor"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="currentColor"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="currentColor"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
             Sign in with Google
           </Button>
         }
         {tokens.msGraphToken ?
-          <div className="flex items-center gap-2 text-sm">
-            <span className="font-medium">
-              {`Logged in to Microsoft • ${Math.round(
+          <div className="flex items-center gap-3">
+            <Badge color="green" className="px-3 py-1.5">
+              <svg
+                className="mr-1.5 h-3 w-3"
+                fill="currentColor"
+                viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              Microsoft
+            </Badge>
+            <span className="text-sm text-zinc-600">
+              {Math.round(
                 ((tokens.msGraphExpiresAt ?? 0) - Date.now()) / 60000
-              )}m left`}
+              )}
+              m remaining
             </span>
-            <button
-              className="text-blue-700 hover:underline"
+            <Button
+              plain
+              className="text-sm"
               onClick={() => signOut(PROVIDERS.MICROSOFT)}>
-              Log Out
-            </button>
+              Sign Out
+            </Button>
           </div>
         : <Button
             color="blue"
             onClick={() =>
               (window.location.href = `/api/auth/${PROVIDERS.MICROSOFT}`)
             }>
-            <span>M</span>
+            <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+              <path fill="#F35325" d="M1 1h10v10H1z" />
+              <path fill="#81BC06" d="M13 1h10v10H13z" />
+              <path fill="#05A6F0" d="M1 13h10v10H1z" />
+              <path fill="#FFBA08" d="M13 13h10v10H13z" />
+            </svg>
             Sign in with Microsoft
           </Button>
         }

--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -1,9 +1,13 @@
 "use client";
 import { LogLevel, StepLogEntry } from "@/types";
-import { Disclosure } from "@headlessui/react";
-import { ChevronDownIcon as ChevronDown } from "@heroicons/react/24/outline";
-import { AnimatePresence, motion } from "framer-motion";
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel
+} from "@headlessui/react";
+import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { Badge } from "./ui/badge";
+import { Table, TableBody, TableCell, TableRow } from "./ui/table";
 
 interface StepLogsProps {
   logs: StepLogEntry[] | undefined;
@@ -12,91 +16,57 @@ interface StepLogsProps {
 export default function StepLogs({ logs }: StepLogsProps) {
   if (!logs || logs.length === 0) return null;
 
-  const levelColor: Record<
-    LogLevel,
-    | "zinc"
-    | "indigo"
-    | "cyan"
-    | "red"
-    | "orange"
-    | "amber"
-    | "yellow"
-    | "lime"
-    | "green"
-    | "emerald"
-    | "teal"
-    | "sky"
-    | "blue"
-    | "violet"
-    | "purple"
-    | "fuchsia"
-    | "pink"
-    | "rose"
-    | undefined
-  > = {
+  const levelColor: Record<LogLevel, "blue" | "amber" | "red" | "zinc"> = {
     [LogLevel.Info]: "blue",
     [LogLevel.Warn]: "amber",
     [LogLevel.Error]: "red",
     [LogLevel.Debug]: "zinc"
   };
 
-  const INDENT = 2;
-
   return (
-    <Disclosure>
-      {({ open }) => (
-        <div className="mt-4">
-          <Disclosure.Button className="flex items-center gap-1 text-sm font-medium text-blue-700 hover:underline">
-            <ChevronDown
-              className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
-            />
-            View logs ({logs.length})
-          </Disclosure.Button>
-          <AnimatePresence initial={false}>
-            {open && (
-              <Disclosure.Panel static>
-                <motion.ul
-                  initial={{ height: 0, opacity: 0 }}
-                  animate={{ height: "auto", opacity: 1 }}
-                  exit={{ height: 0, opacity: 0 }}
-                  transition={{ duration: 0.2 }}
-                  className="mt-2 max-h-96 space-y-2 overflow-auto">
-                  {logs.map((l, idx) => (
-                    <li
-                      key={idx}
-                      className="rounded-lg border border-gray-200 bg-gray-50 p-2 text-xs">
-                      <details className="group open:pb-2">
-                        <summary className="flex cursor-pointer items-center justify-between gap-2">
-                          <span className="flex items-center gap-2">
-                            <span className="text-gray-500">
-                              {new Date(l.timestamp).toLocaleTimeString()}
-                            </span>
-                            {l.level && (
-                              <Badge
-                                className="px-1.5 py-0.5 text-xs"
-                                color={levelColor[l.level]}>
-                                {l.level}
-                              </Badge>
-                            )}
-                          </span>
-                          <span className="flex-1 truncate text-left">
-                            {l.message}
-                          </span>
-                        </summary>
-                        {l.data !== undefined && l.data !== null && (
-                          <pre className="mt-2 whitespace-pre-wrap rounded bg-white p-2 dark:bg-zinc-800">
-                            {JSON.stringify(l.data, null, INDENT)}
-                          </pre>
-                        )}
-                      </details>
-                    </li>
-                  ))}
-                </motion.ul>
-              </Disclosure.Panel>
-            )}
-          </AnimatePresence>
+    <Disclosure as="div" className="mt-4">
+      <DisclosureButton className="group flex w-full items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100">
+        <ChevronRightIcon className="h-4 w-4 transition-transform group-data-[open]:rotate-90" />
+        <span>Logs</span>
+        <Badge color="zinc" className="ml-auto">
+          {logs.length}
+        </Badge>
+      </DisclosureButton>
+
+      <DisclosurePanel className="mt-2 rounded-lg border border-zinc-200 bg-white">
+        <div className="max-h-96 overflow-y-auto">
+          <Table dense bleed>
+            <TableBody>
+              {logs.map((log, idx) => (
+                <TableRow key={idx}>
+                  <TableCell className="w-28 text-xs text-zinc-500">
+                    {new Date(log.timestamp).toLocaleTimeString()}
+                  </TableCell>
+                  <TableCell className="w-20">
+                    {log.level && (
+                      <Badge size="xs" color={levelColor[log.level]}>
+                        {log.level}
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <details className="group">
+                      <summary className="cursor-pointer text-sm">
+                        {log.message}
+                      </summary>
+                      {log.data && (
+                        <pre className="mt-2 overflow-x-auto rounded bg-zinc-50 p-2 text-xs">
+                          {JSON.stringify(log.data, null, 2)}
+                        </pre>
+                      )}
+                    </details>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </div>
-      )}
+      </DisclosurePanel>
     </Disclosure>
   );
 }

--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -5,13 +5,26 @@ import {
   WorkflowVars
 } from "@/app/workflow/variables";
 import { useState } from "react";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import {
-  DescriptionDetails,
-  DescriptionList,
-  DescriptionTerm
-} from "./ui/description-list";
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogDescription,
+  DialogTitle
+} from "./ui/dialog";
+import { Field, Label } from "./ui/fieldset";
 import { Input } from "./ui/input";
+import { Switch } from "./ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "./ui/table";
 
 interface Props {
   vars: Partial<WorkflowVars>;
@@ -19,93 +32,116 @@ interface Props {
 }
 
 export default function VarsInspector({ vars, onChange }: Props) {
+  const [editingVar, setEditingVar] = useState<{
+    name: VarName;
+    value: unknown;
+  } | null>(null);
   const entries = Object.keys(WORKFLOW_VARIABLES) as VarName[];
-  return (
-    <div className="rounded-xl border border-zinc-200 p-4 bg-white shadow-sm">
-      <h2 className="mb-4 text-lg font-semibold text-gray-900">Variables</h2>
-      <DescriptionList className="text-sm">
-        {entries.map((name) => (
-          <VarItem
-            key={name}
-            name={name}
-            type={WORKFLOW_VARIABLES[name]}
-            value={vars[name]}
-            onSave={(val) => onChange({ [name]: val })}
-          />
-        ))}
-      </DescriptionList>
-    </div>
-  );
-}
-
-function VarItem({
-  name,
-  type,
-  value,
-  onSave
-}: {
-  name: VarName;
-  type: "string" | "boolean";
-  value: unknown;
-  onSave(value: unknown): void;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [local, setLocal] = useState(value ?? "");
-
-  const display = value === undefined || value === null ? "" : String(value);
-  const truncated = display.length > 20 ? display.slice(0, 20) + "…" : display;
-
-  const startEdit = () => {
-    setLocal(display);
-    setEditing(true);
-  };
 
   const handleSave = () => {
-    let val: unknown = local;
-    if (type === "boolean") {
-      val = local === "true" || local === true;
+    if (editingVar) {
+      onChange({ [editingVar.name]: editingVar.value });
+      setEditingVar(null);
     }
-    onSave(val as Partial<WorkflowVars>[typeof name]);
-    setEditing(false);
   };
 
   return (
-    <>
-      <DescriptionTerm className="whitespace-nowrap font-mono">
-        {name}
-      </DescriptionTerm>
-      <DescriptionDetails>
-        {editing ?
-          <div className="flex items-center gap-2">
-            {type === "boolean" ?
-              <input
-                type="checkbox"
-                className="h-4 w-4"
-                checked={local === true || local === "true"}
-                onChange={(e) => setLocal(e.target.checked ? "true" : "false")}
+    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm">
+      <div className="border-b border-zinc-200 p-4">
+        <h2 className="text-lg font-semibold text-gray-900">Variables</h2>
+      </div>
+      <div className="max-h-[600px] overflow-y-auto">
+        <Table dense bleed>
+          <TableHead>
+            <TableRow>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Value</TableHeader>
+              <TableHeader className="w-20"></TableHeader>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {entries.map((name) => {
+              const value = vars[name];
+              const type = WORKFLOW_VARIABLES[name];
+              const hasValue = value !== undefined && value !== null;
+
+              return (
+                <TableRow key={name}>
+                  <TableCell className="font-mono text-sm">{name}</TableCell>
+                  <TableCell>
+                    {hasValue ?
+                      type === "boolean" ?
+                        <Badge color={value ? "green" : "zinc"}>
+                          {String(value)}
+                        </Badge>
+                      : <span className="text-sm text-zinc-700 truncate max-w-[200px] block">
+                          {String(value).length > 20 ?
+                            `${String(value).slice(0, 20)}…`
+                          : String(value)}
+                        </span>
+
+                    : <span className="text-sm text-zinc-400 italic">
+                        Not set
+                      </span>
+                    }
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      plain
+                      className="text-xs"
+                      onClick={() =>
+                        setEditingVar({ name, value: value ?? "" })
+                      }>
+                      Edit
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Dialog open={!!editingVar} onClose={() => setEditingVar(null)}>
+        <DialogTitle>Edit Variable</DialogTitle>
+        <DialogDescription>
+          Update the value for{" "}
+          <code className="font-mono">{editingVar?.name}</code>
+        </DialogDescription>
+        <DialogBody>
+          <Field>
+            <Label>Value</Label>
+            {WORKFLOW_VARIABLES[editingVar?.name as VarName] === "boolean" ?
+              <Switch
+                checked={
+                  editingVar?.value === true || editingVar?.value === "true"
+                }
+                onChange={(checked) =>
+                  setEditingVar((prev) =>
+                    prev ? { ...prev, value: checked } : null
+                  )
+                }
               />
             : <Input
-                value={String(local)}
-                onChange={(e) => setLocal(e.target.value)}
+                value={String(editingVar?.value || "")}
+                onChange={(e) =>
+                  setEditingVar((prev) =>
+                    prev ? { ...prev, value: e.target.value } : null
+                  )
+                }
               />
             }
-            <Button color="blue" size="sm" onClick={handleSave}>
-              Save
-            </Button>
-            <Button color="zinc" size="sm" onClick={() => setEditing(false)}>
-              Cancel
-            </Button>
-          </div>
-        : <div className="flex items-center justify-between gap-2">
-            <span className="truncate text-gray-700">{truncated}</span>
-            <button
-              className="text-blue-700 hover:underline text-xs"
-              onClick={startEdit}>
-              Edit
-            </button>
-          </div>
-        }
-      </DescriptionDetails>
-    </>
+          </Field>
+        </DialogBody>
+        <DialogActions>
+          <Button plain onClick={() => setEditingVar(null)}>
+            Cancel
+          </Button>
+          <Button color="blue" onClick={handleSave}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
   );
 }

--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -34,10 +34,17 @@ const colors = {
   zinc: "bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10"
 };
 
-type BadgeProps = { color?: keyof typeof colors };
+const sizes = {
+  xs: "px-1 py-0.5 text-xs",
+  sm: "px-1.5 py-0.5 text-sm/5 sm:text-xs/5",
+  md: "px-2 py-1 text-base/6 sm:text-sm/6"
+};
+
+type BadgeProps = { color?: keyof typeof colors; size?: keyof typeof sizes };
 
 export function Badge({
   color = "zinc",
+  size = "sm",
   className,
   ...props
 }: BadgeProps & React.ComponentPropsWithoutRef<"span">) {
@@ -46,7 +53,8 @@ export function Badge({
       {...props}
       className={clsx(
         className,
-        "inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline",
+        "inline-flex items-center gap-x-1.5 rounded-md font-medium forced-colors:outline",
+        sizes[size],
         colors[color]
       )}
     />
@@ -56,6 +64,7 @@ export function Badge({
 export const BadgeButton = forwardRef(function BadgeButton(
   {
     color = "zinc",
+    size = "sm",
     className,
     children,
     ...props
@@ -76,12 +85,16 @@ export const BadgeButton = forwardRef(function BadgeButton(
         className={classes}
         ref={ref as React.ForwardedRef<HTMLAnchorElement>}>
         <TouchTarget>
-          <Badge color={color}>{children}</Badge>
+          <Badge color={color} size={size}>
+            {children}
+          </Badge>
         </TouchTarget>
       </Link>
     : <Headless.Button {...props} className={classes} ref={ref}>
         <TouchTarget>
-          <Badge color={color}>{children}</Badge>
+          <Badge color={color} size={size}>
+            {children}
+          </Badge>
         </TouchTarget>
       </Headless.Button>;
 });


### PR DESCRIPTION
## Summary
- improve ProviderLogin signed-in view with badges and styled buttons
- redesign VarsInspector with table layout and edit dialog
- clean up StepLogs using Disclosure and table formatting
- add `size` prop to Badge component

## Testing
- `pnpm lint` *(fails: no-explicit-any and other lints)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e6f6b8b8832292bd9a5ee22fa793