### PR TITLE
Simplify provider routes using NextRequest params

### DIFF
--- a/app/api/auth/[provider]/route.ts
+++ b/app/api/auth/[provider]/route.ts
@@ -7,18 +7,20 @@ import {
   setChunkedCookie
 } from "@/lib/auth";
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const provider = url.pathname.split("/").pop() as Provider;
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { provider: Provider } }
+) {
+  const provider = params.provider;
 
   if (provider !== PROVIDERS.GOOGLE && provider !== PROVIDERS.MICROSOFT) {
     return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
   }
 
   const state = generateState();
-  const baseUrl = url.protocol + "//" + url.host;
+  const baseUrl = request.nextUrl.origin;
   const authUrl = generateAuthUrl(provider, state, baseUrl);
 
   const response = NextResponse.redirect(authUrl);

--- a/app/api/auth/callback/[provider]/route.ts
+++ b/app/api/auth/callback/[provider]/route.ts
@@ -1,15 +1,17 @@
 import { Provider } from "@/constants";
 import { exchangeCodeForToken, setToken, validateOAuthState } from "@/lib/auth";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const provider = url.pathname.split("/").pop() as Provider;
-  const searchParams = url.searchParams;
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { provider: Provider } }
+) {
+  const provider = params.provider;
+  const searchParams = request.nextUrl.searchParams;
   const code = searchParams.get("code");
   const state = searchParams.get("state");
   const error = searchParams.get("error");
-  const baseUrl = url.protocol + "//" + url.host;
+  const baseUrl = request.nextUrl.origin;
 
   if (error) {
     console.error(error);

--- a/app/api/auth/signout/[provider]/route.ts
+++ b/app/api/auth/signout/[provider]/route.ts
@@ -1,19 +1,24 @@
 import { Provider } from "@/constants";
 import { clearChunkedCookie } from "@/lib/auth";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Allow GET requests for convenience (e.g. direct link clicks) to sign out.
  */
-export async function GET(request: Request) {
-  return POST(request);
+export async function GET(
+  request: NextRequest,
+  context: { params: { provider: Provider } }
+) {
+  return POST(request, context);
 }
 
-export async function POST(request: Request) {
-  const url = new URL(request.url);
-  const provider = url.pathname.split("/").pop() as Provider;
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { provider: Provider } }
+) {
+  const provider = params.provider;
   const cookieName = `${provider}_token`;
-  const baseUrl = url.protocol + "//" + url.host;
+  const baseUrl = request.nextUrl.origin;
   const response = NextResponse.redirect(`${baseUrl}/`);
   await clearChunkedCookie(response, cookieName);
   return response;


### PR DESCRIPTION
## Summary
- use `NextRequest` and dynamic `params` for callback provider routes
- use `NextRequest` for provider auth URL generator
- use `NextRequest` for signout provider routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e85bbd30832286c7bf8c57e6d9a7