### PR TITLE
Improve right rail UI and fix hydration

### DIFF
--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -46,12 +46,12 @@ export default function VarsInspector({ vars, onChange }: Props) {
   };
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm">
-      <div className="border-b border-zinc-200 p-4">
-        <h2 className="text-lg font-semibold text-gray-900">Variables</h2>
+    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm text-xs">
+      <div className="border-b border-zinc-200 p-2">
+        <h2 className="text-base font-semibold text-gray-900">Variables</h2>
       </div>
       <div className="max-h-[600px] overflow-y-auto">
-        <Table dense bleed>
+        <Table dense bleed className="!whitespace-normal">
           <TableHead>
             <TableRow>
               <TableHeader>Name</TableHeader>
@@ -67,20 +67,20 @@ export default function VarsInspector({ vars, onChange }: Props) {
 
               return (
                 <TableRow key={name}>
-                  <TableCell className="font-mono text-sm">{name}</TableCell>
+                  <TableCell className="font-mono text-xs">{name}</TableCell>
                   <TableCell>
                     {hasValue ?
                       type === "boolean" ?
                         <Badge color={value ? "green" : "zinc"}>
                           {String(value)}
                         </Badge>
-                      : <span className="text-sm text-zinc-700 truncate max-w-[200px] block">
+                      : <span className="text-xs text-zinc-700 truncate max-w-[200px] block">
                           {String(value).length > 20 ?
                             `${String(value).slice(0, 20)}…`
                           : String(value)}
                         </span>
 
-                    : <span className="text-sm text-zinc-400 italic">
+                    : <span className="text-xs text-zinc-400 italic">
                         Not set
                       </span>
                     }

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -20,14 +20,23 @@ interface Props {
 }
 
 export default function WorkflowClient({ steps }: Props) {
-  const defaultPassword = useRef(Math.random().toString(36).slice(-12));
-  const [vars, setVars] = useState<Partial<WorkflowVars>>({
-    [Var.GeneratedPassword]: defaultPassword.current
-  });
+  const initialized = useRef(false);
+  const [vars, setVars] = useState<Partial<WorkflowVars>>({});
   const [status, setStatus] = useState<
     Partial<Record<StepIdValue, StepUIState>>
   >({});
   const [executing, setExecuting] = useState<StepIdValue | null>(null);
+
+  // Generate a default password once on the client to avoid SSR mismatches
+  useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true;
+      setVars((prev) => ({
+        ...prev,
+        [Var.GeneratedPassword]: Math.random().toString(36).slice(-12)
+      }));
+    }
+  }, []);
 
   const updateVars = useCallback((newVars: Partial<WorkflowVars>) => {
     const keys = Object.keys(newVars) as (keyof typeof newVars)[];
@@ -144,7 +153,7 @@ export default function WorkflowClient({ steps }: Props) {
             />
           ))}
         </div>
-        <div className="mt-6 lg:mt-0 lg:w-80 lg:flex-none lg:sticky lg:top-4">
+        <div className="mt-6 lg:mt-0 lg:w-96 lg:flex-none lg:sticky lg:top-4">
           <VarsInspector vars={vars} onChange={updateVars} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- adjust variable inspector font sizes and spacing for compactness
- allow table wrapping to avoid horizontal scrolling
- enlarge inspector width for readability
- generate default password only on client to prevent hydration mismatch

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e99749ec8322930391212a31a363