### PR TITLE
Add undo controls and tweak logs view

### DIFF
--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -45,6 +45,8 @@ interface StepCardProps {
   vars: Partial<WorkflowVars>;
   executing: boolean;
   onExecute(id: StepIdValue): void;
+  onUndo(id: StepIdValue): void;
+  onForce(id: StepIdValue): void;
 }
 
 export default function StepCard({
@@ -53,12 +55,15 @@ export default function StepCard({
   state,
   vars,
   executing,
-  onExecute
+  onExecute,
+  onUndo,
+  onForce
 }: StepCardProps) {
   const missing = definition.requires.filter((v) => !vars[v]);
   const status = state?.status ?? "idle";
   const inProgress =
     status === "checking" || status === "executing" || status === "pending";
+  const executed = status === "complete" || status === "failed";
 
   return (
     <div
@@ -128,16 +133,26 @@ export default function StepCard({
           color="blue"
           className="inline-flex items-center gap-2"
           onClick={() => onExecute(definition.id)}
-          disabled={executing || missing.length > 0}>
+          disabled={executing || missing.length > 0}
+          data-complete={executed}
+          style={{ opacity: executed ? 0.5 : 1 }}>
           Execute <ArrowRight className="h-4 w-4" />
         </Button>
-        {status === "complete" && (
-          <button
-            className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
-            onClick={() => onExecute(definition.id)}
-            disabled={executing || missing.length > 0}>
-            Re-execute
-          </button>
+        {executed && (
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
+              onClick={() => onUndo(definition.id)}
+              disabled={executing}>
+              Undo
+            </button>
+            <button
+              className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
+              onClick={() => onForce(definition.id)}
+              disabled={executing}>
+              Force
+            </button>
+          </div>
         )}
       </div>
 

--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -1,12 +1,10 @@
 "use client";
 import { LogLevel, StepLogEntry } from "@/types";
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel
-} from "@headlessui/react";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
+import { useState } from "react";
 import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { Dialog, DialogActions, DialogBody, DialogTitle } from "./ui/dialog";
 import { Table, TableBody, TableCell, TableRow } from "./ui/table";
 
 interface StepLogsProps {
@@ -14,6 +12,7 @@ interface StepLogsProps {
 }
 
 export default function StepLogs({ logs }: StepLogsProps) {
+  const [open, setOpen] = useState(false);
   if (!logs || logs.length === 0) return null;
 
   const levelColor: Record<LogLevel, "blue" | "amber" | "red" | "zinc"> = {
@@ -24,49 +23,59 @@ export default function StepLogs({ logs }: StepLogsProps) {
   };
 
   return (
-    <Disclosure as="div" className="mt-4">
-      <DisclosureButton className="group flex w-full items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100">
-        <ChevronRightIcon className="h-4 w-4 transition-transform group-data-[open]:rotate-90" />
+    <div className="mt-4">
+      <button
+        className="group flex w-full items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100"
+        onClick={() => setOpen(true)}>
+        <ChevronRightIcon className="h-4 w-4" />
         <span>Logs</span>
         <Badge color="zinc" className="ml-auto">
           {logs.length}
         </Badge>
-      </DisclosureButton>
+      </button>
 
-      <DisclosurePanel className="mt-2 rounded-lg border border-zinc-200 bg-white">
-        <div className="max-h-96 overflow-y-auto">
-          <Table dense bleed>
-            <TableBody>
-              {logs.map((log, idx) => (
-                <TableRow key={idx}>
-                  <TableCell className="w-28 text-xs text-zinc-500">
-                    {new Date(log.timestamp).toLocaleTimeString()}
-                  </TableCell>
-                  <TableCell className="w-20">
-                    {log.level && (
-                      <Badge size="xs" color={levelColor[log.level]}>
-                        {log.level}
-                      </Badge>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <details className="group">
-                      <summary className="cursor-pointer text-sm">
-                        {log.message}
-                      </summary>
-                      {log.data && (
-                        <pre className="mt-2 overflow-x-auto rounded bg-zinc-50 p-2 text-xs">
-                          {JSON.stringify(log.data, null, 2)}
-                        </pre>
+      <Dialog open={open} onClose={() => setOpen(false)} size="3xl">
+        <DialogTitle>Logs</DialogTitle>
+        <DialogBody>
+          <div className="max-h-96 overflow-y-auto">
+            <Table dense bleed>
+              <TableBody>
+                {logs.map((log, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell className="w-28 text-xs text-zinc-500">
+                      {new Date(log.timestamp).toLocaleTimeString()}
+                    </TableCell>
+                    <TableCell className="w-20">
+                      {log.level && (
+                        <Badge size="xs" color={levelColor[log.level]}>
+                          {log.level}
+                        </Badge>
                       )}
-                    </details>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      </DisclosurePanel>
-    </Disclosure>
+                    </TableCell>
+                    <TableCell>
+                      <details className="group">
+                        <summary className="cursor-pointer text-sm">
+                          {log.message}
+                        </summary>
+                        {log.data && (
+                          <pre className="mt-2 overflow-x-auto rounded bg-zinc-50 p-2 text-xs">
+                            {JSON.stringify(log.data, null, 2)}
+                          </pre>
+                        )}
+                      </details>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </DialogBody>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)} plain>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
   );
 }

--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -54,9 +54,8 @@ export default function VarsInspector({ vars, onChange }: Props) {
         <Table dense bleed className="!whitespace-normal">
           <TableHead>
             <TableRow>
-              <TableHeader>Name</TableHeader>
+              <TableHeader className="w-32">Name</TableHeader>
               <TableHeader>Value</TableHeader>
-              <TableHeader className="w-20"></TableHeader>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -67,33 +66,22 @@ export default function VarsInspector({ vars, onChange }: Props) {
 
               return (
                 <TableRow key={name}>
-                  <TableCell className="font-mono text-xs">{name}</TableCell>
-                  <TableCell>
+                  <TableCell className="text-xs font-medium text-zinc-800">
+                    {name}
+                  </TableCell>
+                  <TableCell
+                    onClick={() => setEditingVar({ name, value: value ?? "" })}
+                    className="cursor-pointer text-xs font-mono text-blue-700 underline decoration-dotted">
                     {hasValue ?
                       type === "boolean" ?
                         <Badge color={value ? "green" : "zinc"}>
                           {String(value)}
                         </Badge>
-                      : <span className="text-xs text-zinc-700 truncate max-w-[200px] block">
-                          {String(value).length > 20 ?
-                            `${String(value).slice(0, 20)}…`
-                          : String(value)}
+                      : <span className="truncate max-w-[260px] block">
+                          {String(value)}
                         </span>
 
-                    : <span className="text-xs text-zinc-400 italic">
-                        Not set
-                      </span>
-                    }
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      plain
-                      className="text-xs"
-                      onClick={() =>
-                        setEditingVar({ name, value: value ?? "" })
-                      }>
-                      Edit
-                    </Button>
+                    : <span className="italic text-zinc-400">Not set</span>}
                   </TableCell>
                 </TableRow>
               );

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -105,6 +105,25 @@ export default function WorkflowClient({ steps }: Props) {
     }
   }
 
+  function handleUndo(id: StepIdValue) {
+    const def = steps.find((s) => s.id === id);
+    if (!def) return;
+    setStatus((prev) => ({ ...prev, [id]: { status: "idle" } }));
+    setVars((prev) => {
+      const next = { ...prev };
+      for (const v of def.provides) {
+        delete (next as Record<string, unknown>)[v];
+      }
+      return next;
+    });
+    checkedSteps.current.delete(id);
+  }
+
+  function handleForce(id: StepIdValue) {
+    console.log("Force execute", id);
+    handleExecute(id);
+  }
+
   const completed = steps.filter(
     (s) => status[s.id]?.status === "complete"
   ).length;
@@ -150,6 +169,8 @@ export default function WorkflowClient({ steps }: Props) {
               vars={vars}
               executing={executing !== null}
               onExecute={handleExecute}
+              onUndo={handleUndo}
+              onForce={handleForce}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- dim Execute button once complete
- add Undo & Force actions for executed cards
- show logs in a modal so page height doesn't change
- improve variable table layout and inline edit trigger

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852f2b896448322a14202c52e9d245a