### PR TITLE
Improve logs UI

### DIFF
--- a/app/components/StepLogs.tsx
+++ b/app/components/StepLogs.tsx
@@ -1,10 +1,9 @@
 "use client";
 import { LogLevel, StepLogEntry } from "@/types";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
+import clsx from "clsx";
 import { useState } from "react";
 import { Badge } from "./ui/badge";
-import { Button } from "./ui/button";
-import { Dialog, DialogActions, DialogBody, DialogTitle } from "./ui/dialog";
 import { Table, TableBody, TableCell, TableRow } from "./ui/table";
 
 interface StepLogsProps {
@@ -12,7 +11,7 @@ interface StepLogsProps {
 }
 
 export default function StepLogs({ logs }: StepLogsProps) {
-  const [open, setOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   if (!logs || logs.length === 0) return null;
 
   const levelColor: Record<LogLevel, "blue" | "amber" | "red" | "zinc"> = {
@@ -23,59 +22,55 @@ export default function StepLogs({ logs }: StepLogsProps) {
   };
 
   return (
-    <div className="mt-4">
+    <div className="mt-4 text-xs">
       <button
-        className="group flex w-full items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100"
-        onClick={() => setOpen(true)}>
-        <ChevronRightIcon className="h-4 w-4" />
+        className="group flex w-full items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 font-medium text-zinc-700 hover:bg-zinc-100"
+        onClick={() => setExpanded((prev) => !prev)}>
+        <ChevronRightIcon
+          className={clsx(
+            "h-4 w-4 transition-transform",
+            expanded && "rotate-90"
+          )}
+        />
         <span>Logs</span>
         <Badge color="zinc" className="ml-auto">
           {logs.length}
         </Badge>
       </button>
-
-      <Dialog open={open} onClose={() => setOpen(false)} size="3xl">
-        <DialogTitle>Logs</DialogTitle>
-        <DialogBody>
-          <div className="max-h-96 overflow-y-auto">
-            <Table dense bleed>
-              <TableBody>
-                {logs.map((log, idx) => (
-                  <TableRow key={idx}>
-                    <TableCell className="w-28 text-xs text-zinc-500">
-                      {new Date(log.timestamp).toLocaleTimeString()}
-                    </TableCell>
-                    <TableCell className="w-20">
-                      {log.level && (
-                        <Badge size="xs" color={levelColor[log.level]}>
-                          {log.level}
-                        </Badge>
+      {expanded && (
+        <div className="mt-2 max-h-80 overflow-y-auto">
+          <Table dense bleed>
+            <TableBody>
+              {logs.map((log, idx) => (
+                <TableRow key={idx}>
+                  <TableCell className="w-28 text-xs text-zinc-500">
+                    {new Date(log.timestamp).toLocaleTimeString()}
+                  </TableCell>
+                  <TableCell className="w-20">
+                    {log.level && (
+                      <Badge size="xs" color={levelColor[log.level]}>
+                        {log.level}
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="py-2">
+                    <details className="group">
+                      <summary className="cursor-pointer text-xs">
+                        {log.message}
+                      </summary>
+                      {log.data && (
+                        <pre className="mt-2 max-h-48 overflow-auto rounded bg-zinc-50 p-2 text-[10px]">
+                          {JSON.stringify(log.data, null, 2)}
+                        </pre>
                       )}
-                    </TableCell>
-                    <TableCell>
-                      <details className="group">
-                        <summary className="cursor-pointer text-sm">
-                          {log.message}
-                        </summary>
-                        {log.data && (
-                          <pre className="mt-2 overflow-x-auto rounded bg-zinc-50 p-2 text-xs">
-                            {JSON.stringify(log.data, null, 2)}
-                          </pre>
-                        )}
-                      </details>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        </DialogBody>
-        <DialogActions>
-          <Button onClick={() => setOpen(false)} plain>
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
+                    </details>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show logs inline instead of modal
- resize logs area with scrolling for long lists
- make API responses scrollable

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6852f76416d883229af2bdcfdc134850