### PR TITLE
Fix service user check

### DIFF
--- a/lib/workflow/steps/AGENTS.md
+++ b/lib/workflow/steps/AGENTS.md
@@ -20,6 +20,7 @@ mutations are allowed during step development.
 Every step MUST follow this exact pattern:
 
 1. Define the `CheckData` type for data extracted in your `check()` phase:
+
    - For non-empty payloads, declare an `interface CheckData { … }` listing each field.
    - If your step extracts no data, use the empty alias:
 


### PR DESCRIPTION
## Summary
- fix `create-service-user` step to avoid Zod errors if Google API omits fields
- docs formatting tweak in workflow step guide

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68530d95fd208322971c1a17e0ec6dd1