### PR TITLE
Fix workflow checks and SSO assignment

### DIFF
--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -41,6 +41,7 @@ export default createStep<CheckData>({
             z.object({
               targetGroup: z.string().optional(),
               targetOrgUnit: z.string().optional(),
+              ssoMode: z.string().optional(),
               samlSsoInfo: z
                 .object({ inboundSamlSsoProfile: z.string() })
                 .optional()
@@ -57,11 +58,10 @@ export default createStep<CheckData>({
         { flatten: true }
       );
 
-      const target = `groups/${GroupId.AllUsers}`;
       const exists = inboundSsoAssignments.some(
         (a) =>
-          a.targetGroup === target
-          && a.samlSsoInfo?.inboundSamlSsoProfile === profileId
+          a.samlSsoInfo?.inboundSamlSsoProfile === profileId
+          && a.ssoMode === "SAML_SSO"
       );
 
       if (exists) {
@@ -163,6 +163,8 @@ export default createStep<CheckData>({
             z.object({
               name: z.string(),
               targetGroup: z.string().optional(),
+              targetOrgUnit: z.string().optional(),
+              ssoMode: z.string().optional(),
               samlSsoInfo: z
                 .object({ inboundSamlSsoProfile: z.string() })
                 .optional()
@@ -177,11 +179,10 @@ export default createStep<CheckData>({
         { flatten: true }
       );
 
-      const target = `groups/${GroupId.AllUsers}`;
       const assignment = inboundSsoAssignments.find(
         (a) =>
-          a.targetGroup === target
-          && a.samlSsoInfo?.inboundSamlSsoProfile === profileId
+          a.samlSsoInfo?.inboundSamlSsoProfile === profileId
+          && a.ssoMode === "SAML_SSO"
       );
 
       if (assignment) {


### PR DESCRIPTION
## Summary
- improve service user check to verify org unit
- verify custom role privileges before marking as complete
- detect any existing SSO assignment and handle root OU case

## Testing
- `pnpm test`
- `npx prettier -w lib/workflow/steps/create-service-user.ts lib/workflow/steps/create-admin-role-and-assign-user.ts lib/workflow/steps/assign-users-to-sso.ts`

------
https://chatgpt.com/codex/tasks/task_e_6853633b333c8322800f1e0901c2eaec