### PR TITLE
Add constant step descriptions

### DIFF
--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -8,6 +8,7 @@ import {
   XMarkIcon as X
 } from "@heroicons/react/24/solid";
 import { StepApiCalls } from "./step-card/step-api-calls";
+import { stepDescriptions } from "./step-card/step-descriptions";
 import StepLogs from "./StepLogs";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
@@ -41,6 +42,17 @@ const badgeColor: Record<
   pending: "amber",
   undoing: "purple",
   reverted: "zinc"
+};
+
+const textColor: Record<StepUIState["status"], string> = {
+  idle: "text-zinc-700",
+  checking: "text-blue-700",
+  executing: "text-blue-700",
+  complete: "text-green-700",
+  failed: "text-red-700",
+  pending: "text-amber-700",
+  undoing: "text-purple-700",
+  reverted: "text-zinc-700"
 };
 
 interface StepCardProps {
@@ -99,11 +111,18 @@ export default function StepCard({
         </Badge>
       </div>
 
-      {(state?.summary || state?.error || state?.notes) && (
-        <p className="mt-2 text-sm text-gray-700">
-          {state.summary || state.error || state.notes}
+      <div className="mt-2 flex items-start justify-between gap-4 text-sm">
+        <p className="text-gray-700 flex-1">
+          {stepDescriptions[definition.id]}
         </p>
-      )}
+        {(state?.summary || state?.error || state?.notes) && (
+          <span className={`${textColor[status]} shrink-0 whitespace-nowrap`}>
+            {state.error
+              || (state.summary === "Already complete" ? "" : state.summary)
+              || state.notes}
+          </span>
+        )}
+      </div>
 
       <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div className="rounded-lg bg-gray-50 p-4">

--- a/app/components/step-card/step-descriptions.ts
+++ b/app/components/step-card/step-descriptions.ts
@@ -1,0 +1,24 @@
+import { StepIdValue } from "@/types";
+
+export const stepDescriptions: Record<StepIdValue, string> = {
+  "verify-primary-domain":
+    "Ensure Google Workspace primary domain exists and is verified.",
+  "create-automation-ou":
+    "Ensure the organizational unit `/Automation` exists.",
+  "create-service-user":
+    "Ensure service account email `azuread-provisioning@{primaryDomain}` exists.",
+  "create-admin-role-and-assign-user":
+    "Ensure custom admin role `Microsoft Entra Provisioning` exists with correct privileges and is assigned to the provisioning user.",
+  "configure-google-saml-profile":
+    "Ensure at least one inbound SAML profile exists for Google.",
+  "create-microsoft-apps":
+    "Instantiate provisioning and SSO Microsoft enterprise apps from template.",
+  "configure-microsoft-sync-and-sso":
+    "Configure Azure AD provisioning and SSO settings.",
+  "setup-microsoft-claims-policy":
+    "Ensure a claims mapping policy exists and is assigned to the SSO service principal.",
+  "complete-google-sso-setup":
+    "Automatically configure Google SSO using Azure AD metadata.",
+  "assign-users-to-sso": "Enable SAML SSO for all users in the domain.",
+  "test-sso-configuration": "Verify end-to-end SAML SSO is functioning."
+};


### PR DESCRIPTION
## Summary
- keep a static description for each workflow step
- right-align status details beside the step description

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685366920bb08322bec028f0f106f75f