### PR TITLE
Improve provider button alignment and variables tray

### DIFF
--- a/app/components/ProviderLogin.tsx
+++ b/app/components/ProviderLogin.tsx
@@ -74,7 +74,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
               <>
                 <Button
                   plain
-                  className="w-full justify-center"
+                  className="w-full justify-center items-center"
                   onClick={() => signOut(PROVIDERS.GOOGLE)}>
                   Sign out of Google
                 </Button>
@@ -90,7 +90,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
               </>
             : <Button
                 color="blue"
-                className="w-full justify-center"
+                className="w-full justify-center items-center"
                 onClick={() =>
                   (window.location.href = `/api/auth/${PROVIDERS.GOOGLE}`)
                 }>
@@ -123,7 +123,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
               <>
                 <Button
                   plain
-                  className="w-full justify-center"
+                  className="w-full justify-center items-center"
                   onClick={() => signOut(PROVIDERS.MICROSOFT)}>
                   Sign out of Microsoft
                 </Button>
@@ -139,7 +139,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
               </>
             : <Button
                 color="blue"
-                className="w-full justify-center"
+                className="w-full justify-center items-center"
                 onClick={() =>
                   (window.location.href = `/api/auth/${PROVIDERS.MICROSOFT}`)
                 }>

--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -2,9 +2,10 @@
 import {
   VarName,
   WORKFLOW_VARIABLES,
+  WORKFLOW_VAR_GROUPS,
   WorkflowVars
 } from "@/lib/workflow/variables";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import {
@@ -36,7 +37,7 @@ export default function VarsInspector({ vars, onChange }: Props) {
     name: VarName;
     value: unknown;
   } | null>(null);
-  const entries = Object.keys(WORKFLOW_VARIABLES) as VarName[];
+  const groups = WORKFLOW_VAR_GROUPS;
 
   const handleSave = () => {
     if (editingVar) {
@@ -46,7 +47,7 @@ export default function VarsInspector({ vars, onChange }: Props) {
   };
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm text-xs">
+    <div className="rounded-xl rounded-tl-none border border-zinc-200 bg-white shadow-sm text-xs">
       <div className="border-b border-zinc-200 p-2">
         <h2 className="text-base font-semibold text-gray-900">Variables</h2>
       </div>
@@ -59,33 +60,46 @@ export default function VarsInspector({ vars, onChange }: Props) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {entries.map((name) => {
-              const value = vars[name];
-              const type = WORKFLOW_VARIABLES[name];
-              const hasValue = value !== undefined && value !== null;
-
-              return (
-                <TableRow key={name}>
-                  <TableCell className="text-xs font-medium text-zinc-800">
-                    {name}
-                  </TableCell>
+            {groups.map((group) => (
+              <Fragment key={group.title}>
+                <TableRow>
                   <TableCell
-                    onClick={() => setEditingVar({ name, value: value ?? "" })}
-                    className="cursor-pointer text-xs font-mono text-blue-700 underline decoration-dotted">
-                    {hasValue ?
-                      type === "boolean" ?
-                        <Badge color={value ? "green" : "zinc"}>
-                          {String(value)}
-                        </Badge>
-                      : <span className="truncate max-w-[260px] block">
-                          {String(value)}
-                        </span>
-
-                    : <span className="italic text-zinc-400">Not set</span>}
+                    colSpan={2}
+                    className="bg-zinc-50 font-semibold text-zinc-700">
+                    {group.title}
                   </TableCell>
                 </TableRow>
-              );
-            })}
+                {group.vars.map((name) => {
+                  const value = vars[name];
+                  const type = WORKFLOW_VARIABLES[name];
+                  const hasValue = value !== undefined && value !== null;
+
+                  return (
+                    <TableRow key={name}>
+                      <TableCell className="text-xs font-medium text-zinc-800">
+                        {name}
+                      </TableCell>
+                      <TableCell
+                        onClick={() =>
+                          setEditingVar({ name, value: value ?? "" })
+                        }
+                        className="cursor-pointer text-xs font-mono text-blue-700 underline decoration-dotted">
+                        {hasValue ?
+                          type === "boolean" ?
+                            <Badge color={value ? "green" : "zinc"}>
+                              {String(value)}
+                            </Badge>
+                          : <span className="truncate max-w-[260px] block">
+                              {String(value)}
+                            </span>
+
+                        : <span className="italic text-zinc-400">Not set</span>}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </Fragment>
+            ))}
           </TableBody>
         </Table>
       </div>

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -2,13 +2,13 @@
 
 import { checkStep, runStep, undoStep } from "@/lib/workflow/engine";
 import { StepIdValue, StepUIState, Var, WorkflowVars } from "@/types";
+import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
+import clsx from "clsx";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ProviderLogin from "./ProviderLogin";
 import StepCard, { StepInfo } from "./StepCard";
 import VarsInspector from "./VarsInspector";
 import { Navbar, NavbarLabel, NavbarSection } from "./ui/navbar";
-import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
-import clsx from "clsx";
 import {
   Sidebar,
   SidebarBody,
@@ -202,16 +202,17 @@ export default function WorkflowClient({ steps }: Props) {
       {/* Variables drawer toggle & overlay */}
       <button
         onClick={() => setVarsOpen((open) => !open)}
-        className="fixed top-1/2 right-0 z-50 -translate-y-1/2 rounded-l border border-gray-200 bg-white p-2 shadow">
-        {varsOpen ? (
+        className={clsx(
+          "fixed top-1/2 z-50 -translate-y-1/2 rounded-l border border-gray-200 bg-white p-2 shadow transition-[right] duration-300",
+          varsOpen ? "right-96" : "right-0"
+        )}>
+        {varsOpen ?
           <ChevronRightIcon className="h-4 w-4" />
-        ) : (
-          <ChevronLeftIcon className="h-4 w-4" />
-        )}
+        : <ChevronLeftIcon className="h-4 w-4" />}
       </button>
       <div
         className={clsx(
-          "fixed right-0 top-16 bottom-4 z-40 w-80 overflow-y-auto border-l border-gray-200 bg-white shadow-lg transition-transform duration-300",
+          "fixed right-0 top-24 bottom-8 z-40 w-96 overflow-y-auto rounded-tl-xl border-l border-gray-200 bg-white shadow-lg transition-transform duration-300",
           varsOpen ? "translate-x-0" : "translate-x-full"
         )}>
         <VarsInspector vars={vars} onChange={updateVars} />

--- a/lib/workflow/variables.ts
+++ b/lib/workflow/variables.ts
@@ -35,6 +35,29 @@ export const WORKFLOW_VARIABLES = {
   claimsPolicyId: "string"
 } as const;
 
+export const WORKFLOW_VAR_GROUPS = [
+  { title: "Tokens", vars: ["googleAccessToken", "msGraphToken"] },
+  {
+    title: "Domain",
+    vars: ["primaryDomain", "isDomainVerified", "verificationToken"]
+  },
+  {
+    title: "Service Account",
+    vars: ["provisioningUserId", "provisioningUserEmail", "generatedPassword"]
+  },
+  { title: "Roles", vars: ["adminRoleId", "directoryServiceId"] },
+  {
+    title: "Microsoft Apps",
+    vars: [
+      "ssoServicePrincipalId",
+      "provisioningServicePrincipalId",
+      "ssoAppId"
+    ]
+  },
+  { title: "SAML", vars: ["samlProfileId", "entityId", "acsUrl"] },
+  { title: "Policy", vars: ["claimsPolicyId"] }
+] as const;
+
 // Auto-generate Var enum with PascalCase keys
 function toPascalCase<S extends string>(str: S): Capitalize<S> {
   return (str.charAt(0).toUpperCase() + str.slice(1)) as Capitalize<S>;


### PR DESCRIPTION
## Summary
- tweak provider button layout so icons center better
- expose `WORKFLOW_VAR_GROUPS` and use in `VarsInspector`
- style the vars drawer with more padding, width and rounded edges
- move the vars drawer toggle with smoother transition

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: Property 'privilegeName' does not exist on type '{ serviceId: string; }')*

------
https://chatgpt.com/codex/tasks/task_e_68536714e3d483228b34f1470c17837b