### PR TITLE
Improve workflow UI layout

### DIFF
--- a/app/components/ProviderLogin.tsx
+++ b/app/components/ProviderLogin.tsx
@@ -63,12 +63,12 @@ export default function ProviderLogin({ onUpdate }: Props) {
   }, []);
 
   return (
-    <div className="mb-6 rounded-xl border border-blue-100 bg-gradient-to-r from-blue-50 to-indigo-50 p-6 shadow-sm">
+    <div className="rounded-xl border border-gray-200 bg-gray-50 p-6">
       <h2 className="mb-4 text-lg font-semibold text-gray-900">
         Provider Login
       </h2>
-      <div className="flex gap-4">
-        <div className="flex-1 rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
           <div className="flex flex-col gap-2">
             {tokens.googleAccessToken ?
               <>
@@ -117,7 +117,7 @@ export default function ProviderLogin({ onUpdate }: Props) {
             }
           </div>
         </div>
-        <div className="flex-1 rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
           <div className="flex flex-col gap-2">
             {tokens.msGraphToken ?
               <>

--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -7,6 +7,7 @@ import {
   DocumentPlusIcon as FileStack,
   XMarkIcon as X
 } from "@heroicons/react/24/solid";
+import clsx from "clsx";
 import { StepApiCalls } from "./step-card/step-api-calls";
 import { stepDescriptions } from "./step-card/step-descriptions";
 import StepLogs from "./StepLogs";
@@ -87,106 +88,113 @@ export default function StepCard({
 
   return (
     <div
-      className={`relative mb-6 rounded-xl border ${accent[status]} border-l-4 bg-white p-6 shadow-sm hover:shadow-md transition-shadow duration-200${
-        inProgress ? " animate-pulse" : ""
-      }`}>
+      className={clsx(
+        "relative mb-6 overflow-hidden",
+        "rounded-xl",
+        "border border-l-4",
+        accent[status],
+        "bg-white shadow-sm hover:shadow-md transition-shadow duration-200",
+        inProgress ? "animate-pulse" : ""
+      )}>
       {inProgress && (
-        <div className="absolute left-0 right-0 top-0 h-1 overflow-hidden rounded-t">
+        <div className="absolute left-0 right-0 top-0 h-1 overflow-hidden">
           <div className="animate-indeterminate h-full w-1/2 bg-blue-500" />
         </div>
       )}
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-2">
-          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-xs font-medium text-gray-700">
-            {index + 1}
-          </span>
-          <h3 className="text-lg font-semibold text-gray-900">
-            {definition.id}
-          </h3>
-        </div>
-        <Badge
-          color={badgeColor[status]}
-          className="px-3 py-1 text-xs font-medium capitalize">
-          {status}
-        </Badge>
-      </div>
-
-      <div className="mt-2 flex items-start justify-between gap-4 text-sm">
-        <p className="text-gray-700 flex-1">
-          {stepDescriptions[definition.id]}
-        </p>
-        {(state?.summary || state?.error || state?.notes) && (
-          <span className={`${textColor[status]} shrink-0 whitespace-nowrap`}>
-            {state.error
-              || (state.summary === "Already complete" ? "" : state.summary)
-              || state.notes}
-          </span>
-        )}
-      </div>
-
-      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div className="rounded-lg bg-gray-50 p-4">
-          <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-800">
-            <FileStack className="h-4 w-4" /> Requires
-          </h4>
-          <ul className="space-y-1 text-sm">
-            {definition.requires.map((v) => (
-              <li key={v} className="flex items-center gap-2">
-                <span className="font-mono text-gray-800">{v}</span>
-                {vars[v] ?
-                  <Check className="h-4 w-4 text-green-600" />
-                : <X className="h-4 w-4 text-gray-400" />}
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className="rounded-lg bg-gray-50 p-4">
-          <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-800">
-            <Boxes className="h-4 w-4" /> Provides
-          </h4>
-          <ul className="space-y-1 text-sm">
-            {definition.provides.map((v) => (
-              <li key={v} className="flex items-center gap-2">
-                <span className="font-mono text-gray-800">{v}</span>
-                {vars[v] ?
-                  <Check className="h-4 w-4 text-green-600" />
-                : <X className="h-4 w-4 text-gray-400" />}
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
-
-      <div className="mt-4 flex items-center gap-2">
-        <Button
-          color="blue"
-          className="inline-flex items-center gap-2"
-          onClick={() => onExecute(definition.id)}
-          disabled={executing || missing.length > 0}
-          data-complete={executed}
-          style={{ opacity: executed ? 0.5 : 1 }}>
-          Execute <ArrowRight className="h-4 w-4" />
-        </Button>
-        {executed && (
-          <div className="ml-auto flex items-center gap-2">
-            <button
-              className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
-              onClick={() => onUndo(definition.id)}
-              disabled={executing}>
-              Undo
-            </button>
-            <button
-              className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
-              onClick={() => onForce(definition.id)}
-              disabled={executing}>
-              Force
-            </button>
+      <div className="p-6">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-2">
+            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-xs font-medium text-gray-700">
+              {index + 1}
+            </span>
+            <h3 className="text-lg font-semibold text-gray-900">
+              {definition.id}
+            </h3>
           </div>
-        )}
-      </div>
-      <StepApiCalls stepId={definition.id} />
+          <Badge
+            color={badgeColor[status]}
+            className="px-3 py-1 text-xs font-medium capitalize">
+            {status}
+          </Badge>
+        </div>
 
-      <StepLogs logs={state?.logs} />
+        <div className="mt-2 flex items-start justify-between gap-4 text-sm">
+          <p className="text-gray-700 flex-1">
+            {stepDescriptions[definition.id]}
+          </p>
+          {(state?.summary || state?.error || state?.notes) && (
+            <span className={`${textColor[status]} shrink-0 whitespace-nowrap`}>
+              {state.error
+                || (state.summary === "Already complete" ? "" : state.summary)
+                || state.notes}
+            </span>
+          )}
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="bg-gray-50 p-4">
+            <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-800">
+              <FileStack className="h-4 w-4" /> Requires
+            </h4>
+            <ul className="space-y-1 text-sm">
+              {definition.requires.map((v) => (
+                <li key={v} className="flex items-center gap-2">
+                  <span className="font-mono text-gray-800">{v}</span>
+                  {vars[v] ?
+                    <Check className="h-4 w-4 text-green-600" />
+                  : <X className="h-4 w-4 text-gray-400" />}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="bg-gray-50 p-4">
+            <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-800">
+              <Boxes className="h-4 w-4" /> Provides
+            </h4>
+            <ul className="space-y-1 text-sm">
+              {definition.provides.map((v) => (
+                <li key={v} className="flex items-center gap-2">
+                  <span className="font-mono text-gray-800">{v}</span>
+                  {vars[v] ?
+                    <Check className="h-4 w-4 text-green-600" />
+                  : <X className="h-4 w-4 text-gray-400" />}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-4 flex items-center gap-2">
+          <Button
+            color="blue"
+            className="inline-flex items-center gap-2"
+            onClick={() => onExecute(definition.id)}
+            disabled={executing || missing.length > 0}
+            data-complete={executed}
+            style={{ opacity: executed ? 0.5 : 1 }}>
+            Execute <ArrowRight className="h-4 w-4" />
+          </Button>
+          {executed && (
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
+                onClick={() => onUndo(definition.id)}
+                disabled={executing}>
+                Undo
+              </button>
+              <button
+                className="text-sm text-blue-700 hover:underline disabled:text-gray-300"
+                onClick={() => onForce(definition.id)}
+                disabled={executing}>
+                Force
+              </button>
+            </div>
+          )}
+        </div>
+        <StepApiCalls stepId={definition.id} />
+
+        <StepLogs logs={state?.logs} />
+      </div>
     </div>
   );
 }

--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -47,15 +47,18 @@ export default function VarsInspector({ vars, onChange }: Props) {
   };
 
   return (
-    <div className="rounded-xl rounded-tl-none border border-zinc-200 bg-white shadow-sm text-xs">
-      <div className="border-b border-zinc-200 p-2">
-        <h2 className="text-base font-semibold text-gray-900">Variables</h2>
+    <div className="flex h-full flex-col bg-gray-50">
+      {/* Header - fixed */}
+      <div className="flex-shrink-0 border-b border-gray-200 bg-white px-4 py-3">
+        <h2 className="text-lg font-semibold text-gray-900">Variables</h2>
       </div>
-      <div className="max-h-[600px] overflow-y-auto">
-        <Table dense bleed className="!whitespace-normal">
+
+      {/* Scrollable content - single scroll context */}
+      <div className="flex-1 overflow-y-auto">
+        <Table dense className="!whitespace-normal">
           <TableHead>
             <TableRow>
-              <TableHeader className="w-32">Name</TableHeader>
+              <TableHeader className="w-2/5">Name</TableHeader>
               <TableHeader>Value</TableHeader>
             </TableRow>
           </TableHead>

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -172,49 +172,56 @@ export default function WorkflowClient({ steps }: Props) {
 
   return (
     <StackedLayout navbar={navbar} sidebar={sidebar}>
-      <h1 className="mb-8 text-2xl font-bold text-gray-900">Workflow</h1>
-      <p className="mb-6 text-gray-600">
-        Run each step to configure the environment.
-      </p>
-      <div className="mb-4 text-sm text-gray-600">
-        {completed} of {steps.length} steps complete
-      </div>
-      <div className="lg:flex lg:items-start lg:gap-6">
-        <div className="flex-1">
+      {/* Container for all content - single scroll context */}
+      <div className="min-h-screen">
+        {/* Header section - fixed width, centered */}
+        <div className="mx-auto max-w-2xl px-6 pt-8 pb-6">
+          <h1 className="mb-4 text-2xl font-bold text-gray-900">Workflow</h1>
+          <p className="mb-6 text-gray-600">
+            Run each step to configure the environment.
+          </p>
+          <div className="mb-6 text-sm text-gray-600">
+            {completed} of {steps.length} steps complete
+          </div>
+
+          {/* Provider Login - keep in centered container */}
           <ProviderLogin onUpdate={updateVars} />
+        </div>
+
+        {/* Steps section - full width for cards */}
+        <div className="pb-8">
           {steps.map((step, idx) => (
-            <StepCard
-              key={step.id}
-              index={idx}
-              definition={step}
-              state={status[step.id]}
-              vars={vars}
-              executing={executing !== null}
-              onExecute={handleExecute}
-              onUndo={handleUndo}
-              onForce={handleForce}
-            />
+            <div key={step.id} className="mx-auto max-w-4xl px-6">
+              <StepCard
+                index={idx}
+                definition={step}
+                state={status[step.id]}
+                vars={vars}
+                executing={executing !== null}
+                onExecute={handleExecute}
+                onUndo={handleUndo}
+                onForce={handleForce}
+              />
+            </div>
           ))}
         </div>
-        {/* static sidebar replaced by overlay drawer */}
       </div>
 
-      {/* Variables drawer toggle & overlay */}
-      <button
-        onClick={() => setVarsOpen((open) => !open)}
-        className={clsx(
-          "fixed top-1/2 z-50 -translate-y-1/2 rounded-l border border-gray-200 bg-white p-2 shadow transition-[right] duration-300",
-          varsOpen ? "right-96" : "right-0"
-        )}>
-        {varsOpen ?
-          <ChevronRightIcon className="h-4 w-4" />
-        : <ChevronLeftIcon className="h-4 w-4" />}
-      </button>
+      {/* Variables Panel - fixed position slide-out */}
       <div
         className={clsx(
-          "fixed right-0 top-24 bottom-8 z-40 w-96 overflow-y-auto rounded-tl-xl border-l border-gray-200 bg-white shadow-lg transition-transform duration-300",
+          "fixed right-0 top-0 h-full w-80 transform bg-white shadow-xl transition-transform duration-300 z-50",
           varsOpen ? "translate-x-0" : "translate-x-full"
         )}>
+        {/* Toggle button attached to panel */}
+        <button
+          onClick={() => setVarsOpen(!varsOpen)}
+          className="absolute -left-10 top-24 bg-white border border-r-0 border-gray-200 rounded-l-lg p-2 shadow-sm">
+          {varsOpen ?
+            <ChevronRightIcon className="h-5 w-5 text-gray-600" />
+          : <ChevronLeftIcon className="h-5 w-5 text-gray-600" />}
+        </button>
+
         <VarsInspector vars={vars} onChange={updateVars} />
       </div>
     </StackedLayout>


### PR DESCRIPTION
## Summary
- refactor layout in `WorkflowClient` for single scroll context
- clean up `VarsInspector` with fixed header and scrollable body
- simplify `StepCard` styling and rounding
- lighten `ProviderLogin` design

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68536b36ed448322a0184392e66b884d