### PR TITLE
Add config variables and update workflow steps

### DIFF
--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -36,7 +36,16 @@ export default function WorkflowClient({ steps }: Props) {
       initialized.current = true;
       setVars((prev) => ({
         ...prev,
-        [Var.GeneratedPassword]: Math.random().toString(36).slice(-12)
+        [Var.GeneratedPassword]: Math.random().toString(36).slice(-12),
+        // Add default configuration values
+        [Var.AutomationOuName]: "Automation",
+        [Var.AutomationOuPath]: "/Automation",
+        [Var.ProvisioningUserPrefix]: "azuread-provisioning",
+        [Var.AdminRoleName]: "Microsoft Entra Provisioning",
+        [Var.SamlProfileDisplayName]: "Azure AD",
+        [Var.ProvisioningAppDisplayName]: "Google Workspace Provisioning",
+        [Var.SsoAppDisplayName]: "Google Workspace SSO",
+        [Var.ClaimsPolicyDisplayName]: "Google Workspace Basic Claims"
       }));
     }
   }, []);

--- a/constants.ts
+++ b/constants.ts
@@ -84,11 +84,6 @@ export const SyncTemplateId = { GoogleWorkspace: "google2provisioningV2" };
 
 export const GroupId = { AllUsers: "allUsers" };
 
-export const OrgUnit = {
-  AutomationName: "Automation",
-  AutomationPath: "/Automation",
-  RootPath: "/"
-};
 
 export const PROVIDERS = { GOOGLE: "google", MICROSOFT: "microsoft" } as const;
 

--- a/lib/workflow/steps/configure-google-saml-profile.ts
+++ b/lib/workflow/steps/configure-google-saml-profile.ts
@@ -2,7 +2,7 @@ import { ApiEndpoint } from "@/constants";
 import { EmptyResponseSchema } from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
-import { createStep } from "../create-step";
+import { createStep, getVar } from "../create-step";
 
 interface CheckData {
   samlProfileId?: string;
@@ -12,7 +12,11 @@ interface CheckData {
 
 export default createStep<CheckData>({
   id: StepId.ConfigureGoogleSamlProfile,
-  requires: [Var.GoogleAccessToken, Var.IsDomainVerified],
+  requires: [
+    Var.GoogleAccessToken,
+    Var.IsDomainVerified,
+    Var.SamlProfileDisplayName
+  ],
   provides: [Var.SamlProfileId, Var.EntityId, Var.AcsUrl],
 
   /**
@@ -77,7 +81,7 @@ export default createStep<CheckData>({
     }
   },
 
-  async execute({ fetchGoogle, markSucceeded, markFailed, markPending, log }) {
+  async execute({ vars, fetchGoogle, markSucceeded, markFailed, markPending, log }) {
     /**
      * POST https://cloudidentity.googleapis.com/v1/customers/my_customer/inboundSamlSsoProfiles
      * {
@@ -124,7 +128,7 @@ export default createStep<CheckData>({
       const op = await fetchGoogle(createUrl, opSchema, {
         method: "POST",
         body: JSON.stringify({
-          displayName: "Azure AD",
+          displayName: getVar(vars, Var.SamlProfileDisplayName),
           idpConfig: { entityId: "", singleSignOnServiceUri: "" }
         })
       });

--- a/lib/workflow/steps/create-admin-role-and-assign-user.ts
+++ b/lib/workflow/steps/create-admin-role-and-assign-user.ts
@@ -32,7 +32,8 @@ export default createStep<CheckData>({
   requires: [
     Var.GoogleAccessToken,
     Var.IsDomainVerified,
-    Var.ProvisioningUserId
+    Var.ProvisioningUserId,
+    Var.AdminRoleName
   ],
   provides: [Var.AdminRoleId, Var.DirectoryServiceId],
 
@@ -88,9 +89,8 @@ export default createStep<CheckData>({
         RolesSchema,
         { flatten: true }
       );
-      const role = items.find(
-        (r) => r.roleName === "Microsoft Entra Provisioning"
-      );
+      const roleName = getVar(vars, Var.AdminRoleName);
+      const role = items.find((r) => r.roleName === roleName);
       if (role) {
         const privNames = role.rolePrivileges.map((p) => p.privilegeName);
         const hasPrivs = REQUIRED_PRIVS.every((p) => privNames.includes(p));
@@ -226,7 +226,7 @@ export default createStep<CheckData>({
         const res = await fetchGoogle(ApiEndpoint.Google.Roles, CreateSchema, {
           method: "POST",
           body: JSON.stringify({
-            roleName: "Microsoft Entra Provisioning",
+            roleName: getVar(vars, Var.AdminRoleName),
             roleDescription: "Custom role for Microsoft provisioning",
             rolePrivileges: [
               { serviceId, privilegeName: "ORGANIZATION_UNITS_RETRIEVE" },
@@ -259,9 +259,8 @@ export default createStep<CheckData>({
               RolesSchema,
               { flatten: true }
             );
-            roleId = rolesList.find(
-              (r) => r.roleName === "Microsoft Entra Provisioning"
-            )?.roleId;
+            const roleName = getVar(vars, Var.AdminRoleName);
+            roleId = rolesList.find((r) => r.roleName === roleName)?.roleId;
           }
         } else {
           throw error;

--- a/lib/workflow/steps/create-automation-ou.ts
+++ b/lib/workflow/steps/create-automation-ou.ts
@@ -1,14 +1,19 @@
-import { ApiEndpoint, OrgUnit } from "@/constants";
+import { ApiEndpoint } from "@/constants";
 import { EmptyResponseSchema, isConflictError } from "@/lib/workflow/utils";
 import type { WorkflowVars } from "@/types";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
-import { createStep } from "../create-step";
+import { createStep, getVar } from "../create-step";
 
 type CheckData = Partial<Pick<WorkflowVars, never>>;
 export default createStep<CheckData>({
   id: StepId.CreateAutomationOU,
-  requires: [Var.GoogleAccessToken, Var.IsDomainVerified],
+  requires: [
+    Var.GoogleAccessToken,
+    Var.IsDomainVerified,
+    Var.AutomationOuName,
+    Var.AutomationOuPath
+  ],
   provides: [],
 
   /**
@@ -31,7 +36,7 @@ export default createStep<CheckData>({
    */
 
   async check({
-    vars: _vars,
+    vars,
     fetchGoogle,
     markComplete,
     markIncomplete,
@@ -39,7 +44,7 @@ export default createStep<CheckData>({
     log
   }) {
     try {
-      const ouName = OrgUnit.AutomationName;
+      const ouName = getVar(vars, Var.AutomationOuName);
       const OrgUnitSchema = z.object({ orgUnitPath: z.string() });
       await fetchGoogle(
         `${ApiEndpoint.Google.OrgUnits}/${encodeURIComponent(ouName)}`,
@@ -59,7 +64,7 @@ export default createStep<CheckData>({
     }
   },
 
-  async execute({ vars: _vars, fetchGoogle, markSucceeded, markFailed, log }) {
+  async execute({ vars, fetchGoogle, markSucceeded, markFailed, log }) {
     /**
      * POST https://admin.googleapis.com/admin/directory/v1/customer/my_customer/orgunits
      * {
@@ -87,8 +92,8 @@ export default createStep<CheckData>({
       await fetchGoogle(ApiEndpoint.Google.OrgUnits, CreateSchema, {
         method: "POST",
         body: JSON.stringify({
-          name: OrgUnit.AutomationName,
-          parentOrgUnitPath: OrgUnit.RootPath
+          name: getVar(vars, Var.AutomationOuName),
+          parentOrgUnitPath: "/"
         })
       });
 
@@ -103,10 +108,11 @@ export default createStep<CheckData>({
       }
     }
   },
-  undo: async ({ fetchGoogle, markReverted, markFailed, log }) => {
+  undo: async ({ vars, fetchGoogle, markReverted, markFailed, log }) => {
     try {
+      const path = getVar(vars, Var.AutomationOuPath);
       await fetchGoogle(
-        `${ApiEndpoint.Google.OrgUnits}/${encodeURIComponent(OrgUnit.AutomationName)}`,
+        `${ApiEndpoint.Google.OrgUnits}/${encodeURIComponent(path)}`,
         EmptyResponseSchema,
         { method: "DELETE" }
       );

--- a/lib/workflow/steps/create-microsoft-apps.ts
+++ b/lib/workflow/steps/create-microsoft-apps.ts
@@ -2,7 +2,7 @@ import { ApiEndpoint, TemplateId } from "@/constants";
 import { EmptyResponseSchema } from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
-import { createStep } from "../create-step";
+import { createStep, getVar } from "../create-step";
 
 interface CheckData {
   provisioningServicePrincipalId?: string;
@@ -12,7 +12,11 @@ interface CheckData {
 
 export default createStep<CheckData>({
   id: StepId.CreateMicrosoftApps,
-  requires: [Var.MsGraphToken],
+  requires: [
+    Var.MsGraphToken,
+    Var.ProvisioningAppDisplayName,
+    Var.SsoAppDisplayName
+  ],
   provides: [
     Var.ProvisioningServicePrincipalId,
     Var.SsoServicePrincipalId,
@@ -121,7 +125,7 @@ export default createStep<CheckData>({
     }
   },
 
-  async execute({ fetchMicrosoft, markSucceeded, markFailed, log }) {
+  async execute({ vars, fetchMicrosoft, markSucceeded, markFailed, log }) {
     /**
      * POST https://graph.microsoft.com/v1.0/applicationTemplates/{templateId}/instantiate
      * { "displayName": "Google Workspace Provisioning" }
@@ -150,7 +154,9 @@ export default createStep<CheckData>({
         CreateSchema,
         {
           method: "POST",
-          body: JSON.stringify({ displayName: "Google Workspace Provisioning" })
+          body: JSON.stringify({
+            displayName: getVar(vars, Var.ProvisioningAppDisplayName)
+          })
         }
       );
 
@@ -159,7 +165,9 @@ export default createStep<CheckData>({
         CreateSchema,
         {
           method: "POST",
-          body: JSON.stringify({ displayName: "Google Workspace SSO" })
+          body: JSON.stringify({
+            displayName: getVar(vars, Var.SsoAppDisplayName)
+          })
         }
       );
 

--- a/lib/workflow/steps/create-service-user.ts
+++ b/lib/workflow/steps/create-service-user.ts
@@ -1,4 +1,4 @@
-import { ApiEndpoint, OrgUnit } from "@/constants";
+import { ApiEndpoint } from "@/constants";
 import { EmptyResponseSchema, isConflictError } from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import crypto from "crypto";
@@ -12,7 +12,13 @@ interface CheckData {
 
 export default createStep<CheckData>({
   id: StepId.CreateServiceUser,
-  requires: [Var.GoogleAccessToken, Var.IsDomainVerified, Var.PrimaryDomain],
+  requires: [
+    Var.GoogleAccessToken,
+    Var.IsDomainVerified,
+    Var.PrimaryDomain,
+    Var.ProvisioningUserPrefix,
+    Var.AutomationOuPath
+  ],
   provides: [
     Var.ProvisioningUserId,
     Var.ProvisioningUserEmail,
@@ -42,6 +48,7 @@ export default createStep<CheckData>({
   }) {
     try {
       const domain = getVar(vars, Var.PrimaryDomain);
+      const prefix = getVar(vars, Var.ProvisioningUserPrefix);
 
       const UserSchema = z
         .object({
@@ -50,7 +57,7 @@ export default createStep<CheckData>({
           orgUnitPath: z.string().optional()
         })
         .passthrough();
-      const email = `azuread-provisioning@${domain}`;
+      const email = `${prefix}@${domain}`;
       const url = `${ApiEndpoint.Google.Users}/${encodeURIComponent(email)}?fields=id,primaryEmail`;
       const user = await fetchGoogle(url, UserSchema);
 
@@ -115,18 +122,20 @@ export default createStep<CheckData>({
 
       let user;
       try {
+        const prefix = getVar(vars, Var.ProvisioningUserPrefix);
+        const ouPath = getVar(vars, Var.AutomationOuPath);
         user = await fetchGoogle(ApiEndpoint.Google.Users, CreateSchema, {
           method: "POST",
           body: JSON.stringify({
-            primaryEmail: `azuread-provisioning@${domain}`,
+            primaryEmail: `${prefix}@${domain}`,
             name: { givenName: "Microsoft", familyName: "Provisioning" },
             password,
-            orgUnitPath: OrgUnit.AutomationPath
+            orgUnitPath: ouPath
           })
         });
       } catch (error) {
         if (isConflictError(error)) {
-          const fallbackEmail = `azuread-provisioning@${domain}`;
+          const fallbackEmail = `${getVar(vars, Var.ProvisioningUserPrefix)}@${domain}`;
           const getUrl = `${ApiEndpoint.Google.Users}/${encodeURIComponent(fallbackEmail)}?fields=id,primaryEmail`;
           user = await fetchGoogle(getUrl, CreateSchema);
 

--- a/lib/workflow/steps/setup-microsoft-claims-policy.ts
+++ b/lib/workflow/steps/setup-microsoft-claims-policy.ts
@@ -10,7 +10,11 @@ interface CheckData {
 
 export default createStep<CheckData>({
   id: StepId.SetupMicrosoftClaimsPolicy,
-  requires: [Var.MsGraphToken, Var.SsoServicePrincipalId],
+  requires: [
+    Var.MsGraphToken,
+    Var.SsoServicePrincipalId,
+    Var.ClaimsPolicyDisplayName
+  ],
   provides: [Var.ClaimsPolicyId],
 
   /**
@@ -91,7 +95,7 @@ export default createStep<CheckData>({
               definition: [
                 '{"ClaimsMappingPolicy":{"Version":1,"IncludeBasicClaimSet":true,"ClaimsSchema":[]}}'
               ],
-              displayName: "Google Workspace Basic Claims",
+              displayName: getVar(vars, Var.ClaimsPolicyDisplayName),
               isOrganizationDefault: false
             })
           }

--- a/lib/workflow/variables.ts
+++ b/lib/workflow/variables.ts
@@ -12,6 +12,16 @@ export const WORKFLOW_VARIABLES = {
   isDomainVerified: "boolean",
   verificationToken: "string",
 
+  // Configuration variables
+  automationOuName: "string",
+  automationOuPath: "string",
+  provisioningUserPrefix: "string",
+  adminRoleName: "string",
+  samlProfileDisplayName: "string",
+  provisioningAppDisplayName: "string",
+  ssoAppDisplayName: "string",
+  claimsPolicyDisplayName: "string",
+
   // Service account
   provisioningUserId: "string",
   provisioningUserEmail: "string",
@@ -40,6 +50,19 @@ export const WORKFLOW_VAR_GROUPS = [
   {
     title: "Domain",
     vars: ["primaryDomain", "isDomainVerified", "verificationToken"]
+  },
+  {
+    title: "Configuration",
+    vars: [
+      "automationOuName",
+      "automationOuPath",
+      "provisioningUserPrefix",
+      "adminRoleName",
+      "samlProfileDisplayName",
+      "provisioningAppDisplayName",
+      "ssoAppDisplayName",
+      "claimsPolicyDisplayName"
+    ]
   },
   {
     title: "Service Account",


### PR DESCRIPTION
## Summary
- extend workflow variable system with configuration variables and group
- set default config vars in WorkflowClient
- remove `OrgUnit` constant
- update workflow steps to use new variables
- update Microsoft/GW app names via vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68536d9f50d883229f6e7d896ff9f286