### PR TITLE
Implement fetch utils, token refresh, validators

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,14 +1,14 @@
 import { PROVIDERS } from "@/constants";
-import { getToken } from "@/lib/auth";
+import { refreshTokenIfNeeded } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  const google = await getToken(PROVIDERS.GOOGLE);
-  const microsoft = await getToken(PROVIDERS.MICROSOFT);
+  const googleToken = await refreshTokenIfNeeded(PROVIDERS.GOOGLE);
+  const microsoftToken = await refreshTokenIfNeeded(PROVIDERS.MICROSOFT);
   return NextResponse.json({
-    googleAccessToken: google?.accessToken,
-    googleExpiresAt: google?.expiresAt,
-    msGraphToken: microsoft?.accessToken,
-    msGraphExpiresAt: microsoft?.expiresAt
+    googleAccessToken: googleToken?.accessToken,
+    googleExpiresAt: googleToken?.expiresAt,
+    msGraphToken: microsoftToken?.accessToken,
+    msGraphExpiresAt: microsoftToken?.expiresAt
   });
 }

--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { validateVariableRelationships } from "@/lib/workflow/variable-validators";
 import {
   VarName,
   WORKFLOW_VARIABLES,
@@ -38,6 +39,7 @@ export default function VarsInspector({ vars, onChange }: Props) {
     value: unknown;
   } | null>(null);
   const groups = WORKFLOW_VAR_GROUPS;
+  const validationErrors = validateVariableRelationships(vars);
 
   const handleSave = () => {
     if (editingVar) {
@@ -52,6 +54,18 @@ export default function VarsInspector({ vars, onChange }: Props) {
       <div className="flex-shrink-0 border-b border-gray-200 bg-white px-4 py-3">
         <h2 className="text-lg font-semibold text-gray-900">Variables</h2>
       </div>
+      {validationErrors.length > 0 && (
+        <div className="border-b border-zinc-200 bg-red-50 p-2">
+          <h3 className="text-sm font-medium text-red-800 mb-1">
+            Variable Validation Errors
+          </h3>
+          <ul className="text-xs text-red-700 space-y-1">
+            {validationErrors.map((error, i) => (
+              <li key={i}>• {error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* Scrollable content - single scroll context */}
       <div className="flex-1 overflow-y-auto">

--- a/lib/workflow/engine.ts
+++ b/lib/workflow/engine.ts
@@ -24,7 +24,7 @@ import {
   Var,
   WorkflowVars
 } from "@/types";
-import { z } from "zod";
+import { createAuthenticatedFetch } from "./fetch-utils";
 import { getStep } from "./step-registry";
 
 async function processStep<T extends StepIdValue>(
@@ -52,109 +52,15 @@ async function processStep<T extends StepIdValue>(
     pushState({});
   };
 
-  const createFetch = (token: string | undefined) => {
-    type FetchOpts = RequestInit & { flatten?: boolean };
-    return async <T>(
-      url: string,
-      schema: z.ZodSchema<T>,
-      init?: FetchOpts
-    ): Promise<T> => {
-      if (!token) throw new Error("No auth token available");
-
-      // Extract flatten flag from init, and prepare request options
-      const { flatten, ...reqInit } = (init as FetchOpts) ?? {};
-
-      // Single-page fetch helper
-      const fetchPage = async (pageUrl: string): Promise<T> => {
-        const method = reqInit.method ?? "GET";
-        const body = reqInit.body;
-        let parsedBody: unknown;
-        if (body) {
-          try {
-            parsedBody = JSON.parse(body as string);
-          } catch {
-            parsedBody = body;
-          }
-        }
-        addLog({
-          timestamp: Date.now(),
-          message: `Request ${method} ${pageUrl}`,
-          data: {
-            url: pageUrl,
-            method,
-            headers: reqInit.headers,
-            body: parsedBody
-          },
-          level: LogLevel.Debug
-        });
-
-        const res = await fetch(pageUrl, {
-          ...reqInit,
-          headers: {
-            ...(reqInit.headers ?? {}),
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json"
-          }
-        });
-        const clone = res.clone();
-        let logData: unknown;
-        try {
-          logData = await clone.json();
-        } catch {
-          logData = await clone.text();
-        }
-        addLog({
-          timestamp: Date.now(),
-          message: `Response ${res.status} ${pageUrl}`,
-          data: logData,
-          level: LogLevel.Debug
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-        // Attempt to parse JSON; empty responses (e.g. 204 No Content) yield an empty object
-        let json: unknown;
-        try {
-          json = await res.json();
-        } catch {
-          json = {};
-        }
-        return schema.parse(json);
-      };
-
-      // If flatten is requested, accumulate paginated 'items'
-      if (flatten) {
-        let aggregated: T | undefined;
-        let nextToken: string | undefined;
-        const allItems: unknown[] = [];
-        const baseUrl = url;
-        do {
-          let pageUrl = baseUrl;
-          if (nextToken) {
-            const sep = baseUrl.includes("?") ? "&" : "?";
-            pageUrl = `${baseUrl}${sep}pageToken=${encodeURIComponent(nextToken)}`;
-          }
-          const page = await fetchPage(pageUrl);
-          if (aggregated === undefined) aggregated = page;
-          const p = page as unknown as {
-            items?: unknown[];
-            nextPageToken?: string;
-          };
-          if (Array.isArray(p.items)) allItems.push(...p.items);
-          nextToken = p.nextPageToken;
-        } while (nextToken);
-        const result = aggregated as unknown as { items: unknown[] };
-        result.items = allItems;
-        delete (result as unknown as { nextPageToken?: string }).nextPageToken;
-        return aggregated!;
-      }
-
-      // Default single fetch
-      return fetchPage(url);
-    };
-  };
-
   const baseContext = {
-    fetchGoogle: createFetch(vars[Var.GoogleAccessToken] as string | undefined),
-    fetchMicrosoft: createFetch(vars[Var.MsGraphToken] as string | undefined),
+    fetchGoogle: createAuthenticatedFetch(
+      vars[Var.GoogleAccessToken] as string | undefined,
+      { addLog }
+    ),
+    fetchMicrosoft: createAuthenticatedFetch(
+      vars[Var.MsGraphToken] as string | undefined,
+      { addLog }
+    ),
     log: (level: LogLevel, message: string, data?: unknown) => {
       addLog({ timestamp: Date.now(), message, data, level });
     }
@@ -281,105 +187,15 @@ async function processUndoStep<T extends StepIdValue>(
     pushState({});
   };
 
-  const createFetch = (token: string | undefined) => {
-    type FetchOpts = RequestInit & { flatten?: boolean };
-    return async <T>(
-      url: string,
-      schema: z.ZodSchema<T>,
-      init?: FetchOpts
-    ): Promise<T> => {
-      if (!token) throw new Error("No auth token available");
-
-      const { flatten, ...reqInit } = (init as FetchOpts) ?? {};
-
-      const fetchPage = async (pageUrl: string): Promise<T> => {
-        const method = reqInit.method ?? "GET";
-        const body = reqInit.body;
-        let parsedBody: unknown;
-        if (body) {
-          try {
-            parsedBody = JSON.parse(body as string);
-          } catch {
-            parsedBody = body;
-          }
-        }
-        addLog({
-          timestamp: Date.now(),
-          message: `Request ${method} ${pageUrl}`,
-          data: {
-            url: pageUrl,
-            method,
-            headers: reqInit.headers,
-            body: parsedBody
-          },
-          level: LogLevel.Debug
-        });
-
-        const res = await fetch(pageUrl, {
-          ...reqInit,
-          headers: {
-            ...(reqInit.headers ?? {}),
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json"
-          }
-        });
-        const clone = res.clone();
-        let logData: unknown;
-        try {
-          logData = await clone.json();
-        } catch {
-          logData = await clone.text();
-        }
-        addLog({
-          timestamp: Date.now(),
-          message: `Response ${res.status} ${pageUrl}`,
-          data: logData,
-          level: LogLevel.Debug
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-        // Handle empty response (e.g. 204 No Content) by falling back to an empty object
-        let json: unknown;
-        try {
-          json = await res.json();
-        } catch {
-          json = {};
-        }
-        return schema.parse(json);
-      };
-
-      if (flatten) {
-        let aggregated: T | undefined;
-        let nextToken: string | undefined;
-        const allItems: unknown[] = [];
-        const baseUrl = url;
-        do {
-          let pageUrl = baseUrl;
-          if (nextToken) {
-            const sep = baseUrl.includes("?") ? "&" : "?";
-            pageUrl = `${baseUrl}${sep}pageToken=${encodeURIComponent(nextToken)}`;
-          }
-          const page = await fetchPage(pageUrl);
-          if (aggregated === undefined) aggregated = page;
-          const p = page as unknown as {
-            items?: unknown[];
-            nextPageToken?: string;
-          };
-          if (Array.isArray(p.items)) allItems.push(...p.items);
-          nextToken = p.nextPageToken;
-        } while (nextToken);
-        const result = aggregated as unknown as { items: unknown[] };
-        result.items = allItems;
-        delete (result as unknown as { nextPageToken?: string }).nextPageToken;
-        return aggregated!;
-      }
-
-      return fetchPage(url);
-    };
-  };
-
   const baseContext = {
-    fetchGoogle: createFetch(vars[Var.GoogleAccessToken] as string | undefined),
-    fetchMicrosoft: createFetch(vars[Var.MsGraphToken] as string | undefined),
+    fetchGoogle: createAuthenticatedFetch(
+      vars[Var.GoogleAccessToken] as string | undefined,
+      { addLog }
+    ),
+    fetchMicrosoft: createAuthenticatedFetch(
+      vars[Var.MsGraphToken] as string | undefined,
+      { addLog }
+    ),
     log: (level: LogLevel, message: string, data?: unknown) => {
       addLog({ timestamp: Date.now(), message, data, level });
     }

--- a/lib/workflow/fetch-utils.ts
+++ b/lib/workflow/fetch-utils.ts
@@ -1,0 +1,112 @@
+import { LogLevel, StepLogEntry } from "@/types";
+import { z } from "zod";
+
+export type FetchOpts = RequestInit & { flatten?: boolean };
+
+export interface FetchContext {
+  addLog: (entry: StepLogEntry) => void;
+}
+
+export function createAuthenticatedFetch(
+  token: string | undefined,
+  context: FetchContext
+) {
+  return async <T>(
+    url: string,
+    schema: z.ZodSchema<T>,
+    init?: FetchOpts
+  ): Promise<T> => {
+    if (!token) throw new Error("No auth token available");
+
+    const { flatten, ...reqInit } = (init as FetchOpts) ?? {};
+
+    const fetchPage = async (pageUrl: string): Promise<T> => {
+      const method = reqInit.method ?? "GET";
+      const body = reqInit.body;
+      let parsedBody: unknown;
+      if (body) {
+        try {
+          parsedBody = JSON.parse(body as string);
+        } catch {
+          parsedBody = body;
+        }
+      }
+
+      context.addLog({
+        timestamp: Date.now(),
+        message: `Request ${method} ${pageUrl}`,
+        data: {
+          url: pageUrl,
+          method,
+          headers: reqInit.headers,
+          body: parsedBody
+        },
+        level: LogLevel.Debug
+      });
+
+      const res = await fetch(pageUrl, {
+        ...reqInit,
+        headers: {
+          ...(reqInit.headers ?? {}),
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json"
+        }
+      });
+
+      const clone = res.clone();
+      let logData: unknown;
+      try {
+        logData = await clone.json();
+      } catch {
+        logData = await clone.text();
+      }
+
+      context.addLog({
+        timestamp: Date.now(),
+        message: `Response ${res.status} ${pageUrl}`,
+        data: logData,
+        level: LogLevel.Debug
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+
+      let json: unknown;
+      try {
+        json = await res.json();
+      } catch {
+        json = {};
+      }
+      return schema.parse(json);
+    };
+
+    if (flatten) {
+      let aggregated: T | undefined;
+      let nextToken: string | undefined;
+      const allItems: unknown[] = [];
+      const baseUrl = url;
+
+      do {
+        let pageUrl = baseUrl;
+        if (nextToken) {
+          const sep = baseUrl.includes("?") ? "&" : "?";
+          pageUrl = `${baseUrl}${sep}pageToken=${encodeURIComponent(nextToken)}`;
+        }
+        const page = await fetchPage(pageUrl);
+        if (aggregated === undefined) aggregated = page;
+        const p = page as unknown as {
+          items?: unknown[];
+          nextPageToken?: string;
+        };
+        if (Array.isArray(p.items)) allItems.push(...p.items);
+        nextToken = p.nextPageToken;
+      } while (nextToken);
+
+      const result = aggregated as unknown as { items: unknown[] };
+      result.items = allItems;
+      delete (result as unknown as { nextPageToken?: string }).nextPageToken;
+      return aggregated!;
+    }
+
+    return fetchPage(url);
+  };
+}

--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -1,5 +1,9 @@
 import { ApiEndpoint, GroupId } from "@/constants";
-import { EmptyResponseSchema, isConflictError } from "@/lib/workflow/utils";
+import {
+  EmptyResponseSchema,
+  isConflictError,
+  isNotFoundError
+} from "@/lib/workflow/utils";
 import type { WorkflowVars } from "@/types";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
@@ -201,7 +205,7 @@ export default createStep<CheckData>({
 
       markReverted();
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith("HTTP 404")) {
+      if (isNotFoundError(error)) {
         markReverted();
       } else {
         log(LogLevel.Error, "Failed to delete SSO assignment", { error });

--- a/lib/workflow/steps/configure-google-saml-profile.ts
+++ b/lib/workflow/steps/configure-google-saml-profile.ts
@@ -1,5 +1,5 @@
 import { ApiEndpoint } from "@/constants";
-import { EmptyResponseSchema } from "@/lib/workflow/utils";
+import { EmptyResponseSchema, isNotFoundError } from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
 import { createStep } from "../create-step";
@@ -171,7 +171,7 @@ export default createStep<CheckData>({
       );
       markReverted();
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith("HTTP 404")) {
+      if (isNotFoundError(error)) {
         markReverted();
       } else {
         log(LogLevel.Error, "Failed to delete SAML profile", { error });

--- a/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
+++ b/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
@@ -1,5 +1,5 @@
 import { ApiEndpoint, SyncTemplateId } from "@/constants";
-import { EmptyResponseSchema } from "@/lib/workflow/utils";
+import { EmptyResponseSchema, isNotFoundError } from "@/lib/workflow/utils";
 import type { WorkflowVars } from "@/types";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
@@ -150,7 +150,7 @@ export default createStep<CheckData>({
 
       markReverted();
     } catch (error) {
-      if (error instanceof Error && error.message.includes("404")) {
+      if (isNotFoundError(error)) {
         markReverted();
       } else {
         log(LogLevel.Error, "Failed to remove sync job", { error });

--- a/lib/workflow/steps/create-admin-role-and-assign-user.ts
+++ b/lib/workflow/steps/create-admin-role-and-assign-user.ts
@@ -2,7 +2,8 @@ import { ApiEndpoint } from "@/constants";
 import {
   EmptyResponseSchema,
   findInTree,
-  isConflictError
+  isConflictError,
+  isNotFoundError
 } from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
@@ -248,7 +249,10 @@ export default createStep<CheckData>({
                     roleId: z.string(),
                     roleName: z.string(),
                     rolePrivileges: z.array(
-                      z.object({ serviceId: z.string(), privilegeName: z.string() })
+                      z.object({
+                        serviceId: z.string(),
+                        privilegeName: z.string()
+                      })
                     )
                   })
                 )
@@ -358,7 +362,7 @@ export default createStep<CheckData>({
       );
       markReverted();
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith("HTTP 404")) {
+      if (isNotFoundError(error)) {
         markReverted();
       } else {
         log(LogLevel.Error, "Failed to undo admin role", { error });

--- a/lib/workflow/steps/create-automation-ou.ts
+++ b/lib/workflow/steps/create-automation-ou.ts
@@ -1,5 +1,9 @@
 import { ApiEndpoint, OrgUnit } from "@/constants";
-import { EmptyResponseSchema, isConflictError } from "@/lib/workflow/utils";
+import {
+  EmptyResponseSchema,
+  isConflictError,
+  isNotFoundError
+} from "@/lib/workflow/utils";
 import type { WorkflowVars } from "@/types";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
@@ -48,7 +52,7 @@ export default createStep<CheckData>({
       log(LogLevel.Info, "Automation OU already exists");
       markComplete({});
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith("HTTP 404")) {
+      if (isNotFoundError(error)) {
         markIncomplete("Automation OU missing", {});
       } else {
         log(LogLevel.Error, "Failed to check OU", { error });
@@ -112,7 +116,7 @@ export default createStep<CheckData>({
       );
       markReverted();
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith("HTTP 404")) {
+      if (isNotFoundError(error)) {
         markReverted();
       } else {
         log(LogLevel.Error, "Failed to delete OU", { error });

--- a/lib/workflow/steps/create-microsoft-apps.ts
+++ b/lib/workflow/steps/create-microsoft-apps.ts
@@ -1,5 +1,5 @@
 import { ApiEndpoint, TemplateId } from "@/constants";
-import { EmptyResponseSchema } from "@/lib/workflow/utils";
+import { EmptyResponseSchema, isNotFoundError } from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
 import { createStep } from "../create-step";
@@ -207,7 +207,7 @@ export default createStep<CheckData>({
 
       markReverted();
     } catch (error) {
-      if (error instanceof Error && error.message.includes("404")) {
+      if (isNotFoundError(error)) {
         markReverted();
       } else {
         log(LogLevel.Error, "Failed to delete Microsoft apps", { error });

--- a/lib/workflow/steps/setup-microsoft-claims-policy.ts
+++ b/lib/workflow/steps/setup-microsoft-claims-policy.ts
@@ -1,5 +1,9 @@
 import { ApiEndpoint } from "@/constants";
-import { EmptyResponseSchema, isConflictError } from "@/lib/workflow/utils";
+import {
+  EmptyResponseSchema,
+  isConflictError,
+  isNotFoundError
+} from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
 import { createStep, getVar } from "../create-step";
@@ -164,7 +168,7 @@ export default createStep<CheckData>({
 
       markReverted();
     } catch (error) {
-      if (error instanceof Error && error.message.includes("404")) {
+      if (isNotFoundError(error)) {
         markReverted();
       } else {
         log(LogLevel.Error, "Failed to delete claims policy", { error });

--- a/lib/workflow/utils.ts
+++ b/lib/workflow/utils.ts
@@ -1,10 +1,38 @@
 import { z } from "zod";
 
 /**
- * Check if an error is a 409 Conflict error
+ * HTTP error detection utilities
  */
+export function isHttpError(error: unknown, statusCode: number): boolean {
+  if (!(error instanceof Error)) return false;
+  const patterns = [
+    `HTTP ${statusCode}`,
+    `${statusCode}:`,
+    `code": ${statusCode}`,
+    `"code":${statusCode}`
+  ];
+  return patterns.some((pattern) => error.message.includes(pattern));
+}
+
+export function isNotFoundError(error: unknown): boolean {
+  return isHttpError(error, 404);
+}
+
 export function isConflictError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("409");
+  return isHttpError(error, 409);
+}
+
+export function isPreconditionFailedError(error: unknown): boolean {
+  return isHttpError(error, 412);
+}
+
+export function getErrorStatusCode(error: unknown): number | null {
+  if (!(error instanceof Error)) return null;
+  const match = error.message.match(/HTTP (\d{3})|(\d{3}):|code":\s*(\d{3})/);
+  if (match) {
+    return parseInt(match[1] || match[2] || match[3], 10);
+  }
+  return null;
 }
 
 /**

--- a/lib/workflow/variable-validators.ts
+++ b/lib/workflow/variable-validators.ts
@@ -1,0 +1,55 @@
+import { VarName, WorkflowVars } from "@/types";
+
+export interface VariableRelationship {
+  dependent: VarName;
+  requires: VarName[];
+  validate?: (vars: Partial<WorkflowVars>) => string | null;
+}
+
+export const VARIABLE_RELATIONSHIPS: VariableRelationship[] = [
+  {
+    dependent: "provisioningUserEmail" as VarName,
+    requires: ["primaryDomain", "provisioningUserPrefix"] as VarName[],
+    validate: (vars) => {
+      const email = vars.provisioningUserEmail;
+      const expectedEmail = `${vars.provisioningUserPrefix}@${vars.primaryDomain}`;
+      if (email && email !== expectedEmail) {
+        return `Email should be ${expectedEmail}`;
+      }
+      return null;
+    }
+  },
+  {
+    dependent: "adminRoleId" as VarName,
+    requires: ["directoryServiceId"] as VarName[],
+    validate: (vars) => {
+      if (vars.adminRoleId && !vars.directoryServiceId) {
+        return "Admin role requires directory service ID";
+      }
+      return null;
+    }
+  }
+];
+
+export function validateVariableRelationships(
+  vars: Partial<WorkflowVars>
+): string[] {
+  const errors: string[] = [];
+
+  for (const relationship of VARIABLE_RELATIONSHIPS) {
+    if (vars[relationship.dependent]) {
+      for (const req of relationship.requires) {
+        if (!vars[req]) {
+          errors.push(`${relationship.dependent} requires ${req} to be set`);
+        }
+      }
+    }
+
+    if (relationship.validate) {
+      const error = relationship.validate(vars);
+      if (error) errors.push(error);
+    }
+  }
+
+  return errors;
+}

--- a/lib/workflow/variables.ts
+++ b/lib/workflow/variables.ts
@@ -15,6 +15,7 @@ export const WORKFLOW_VARIABLES = {
   // Service account
   provisioningUserId: "string",
   provisioningUserEmail: "string",
+  provisioningUserPrefix: "string",
   generatedPassword: "string",
 
   // Roles
@@ -43,7 +44,12 @@ export const WORKFLOW_VAR_GROUPS = [
   },
   {
     title: "Service Account",
-    vars: ["provisioningUserId", "provisioningUserEmail", "generatedPassword"]
+    vars: [
+      "provisioningUserId",
+      "provisioningUserEmail",
+      "provisioningUserPrefix",
+      "generatedPassword"
+    ]
   },
   { title: "Roles", vars: ["adminRoleId", "directoryServiceId"] },
   {


### PR DESCRIPTION
## Summary
- add authenticated fetch helper and use in engine
- add HTTP error utils
- refresh tokens automatically on session fetch
- validate workflow variable relationships
- show validation errors in VarsInspector
- add token refresh helper

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68536da6f464832290a2d270a8157bb9