### PR TITLE
Enhance workflow variable UI

### DIFF
--- a/app/components/StepCard.tsx
+++ b/app/components/StepCard.tsx
@@ -13,6 +13,7 @@ import { stepDescriptions } from "./step-card/step-descriptions";
 import StepLogs from "./StepLogs";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
+import { StepVariables } from "./step-card/StepVariables";
 
 export interface StepInfo {
   id: StepIdValue;
@@ -65,6 +66,7 @@ interface StepCardProps {
   onExecute(id: StepIdValue): void;
   onUndo(id: StepIdValue): void;
   onForce(id: StepIdValue): void;
+  onVarChange(key: VarName, value: unknown): void;
 }
 
 export default function StepCard({
@@ -75,7 +77,8 @@ export default function StepCard({
   executing,
   onExecute,
   onUndo,
-  onForce
+  onForce,
+  onVarChange
 }: StepCardProps) {
   const missing = definition.requires.filter((v) => !vars[v]);
   const status = state?.status ?? "idle";
@@ -163,6 +166,12 @@ export default function StepCard({
             </ul>
           </div>
         </div>
+
+        <StepVariables
+          stepId={definition.id}
+          vars={vars}
+          onChange={onVarChange}
+        />
 
         <div className="mt-4 flex items-center gap-2">
           <Button

--- a/app/components/VarsInspector.tsx
+++ b/app/components/VarsInspector.tsx
@@ -3,10 +3,12 @@ import { validateVariableRelationships } from "@/lib/workflow/variable-validator
 import {
   VarName,
   WORKFLOW_VARIABLES,
-  WORKFLOW_VAR_GROUPS,
+  VariableMetadata,
   WorkflowVars
 } from "@/lib/workflow/variables";
 import { useState } from "react";
+import clsx from "clsx";
+import { PencilSquareIcon as EditIcon } from "@heroicons/react/24/solid";
 import { Button } from "./ui/button";
 import {
   Dialog,
@@ -19,6 +21,13 @@ import { Field, Label } from "./ui/fieldset";
 import { Input } from "./ui/input";
 import { Switch } from "./ui/switch";
 
+const categoryTitles = {
+  auth: "Auth",
+  domain: "Domain",
+  config: "Config",
+  state: "State"
+} as const;
+
 interface Props {
   vars: Partial<WorkflowVars>;
   onChange(vars: Partial<WorkflowVars>): void;
@@ -29,8 +38,17 @@ export default function VarsInspector({ vars, onChange }: Props) {
     name: VarName;
     value: unknown;
   } | null>(null);
-  const groups = WORKFLOW_VAR_GROUPS;
+  const [filter, setFilter] = useState<'all' | 'config' | 'state'>('all');
   const validationErrors = validateVariableRelationships(vars);
+
+  const groupedVars = Object.entries(WORKFLOW_VARIABLES)
+    .filter(([_, meta]) => filter === 'all' || meta.category === filter)
+    .reduce((acc, [key, meta]) => {
+      const category = meta.category;
+      if (!acc[category]) acc[category] = [];
+      acc[category].push({ key: key as VarName, ...(meta as VariableMetadata) });
+      return acc;
+    }, {} as Record<string, Array<{ key: VarName } & VariableMetadata>>);
 
   const handleSave = () => {
     if (editingVar) {
@@ -42,8 +60,37 @@ export default function VarsInspector({ vars, onChange }: Props) {
   return (
     <div className="flex h-full flex-col bg-white">
       {/* Header */}
-      <div className="flex-shrink-0 border-b border-gray-200 px-3 py-2">
+      <div className="flex-shrink-0 border-b border-gray-200 p-3">
         <h2 className="text-sm font-semibold text-gray-900">Variables</h2>
+        <div className="mt-2 flex gap-2">
+          <button
+            onClick={() => setFilter('all')}
+            className={clsx(
+              'text-xs px-2 py-1 rounded',
+              filter === 'all' ? 'bg-blue-100 text-blue-700' : 'text-gray-600'
+            )}
+          >
+            All
+          </button>
+          <button
+            onClick={() => setFilter('config')}
+            className={clsx(
+              'text-xs px-2 py-1 rounded',
+              filter === 'config' ? 'bg-blue-100 text-blue-700' : 'text-gray-600'
+            )}
+          >
+            Config
+          </button>
+          <button
+            onClick={() => setFilter('state')}
+            className={clsx(
+              'text-xs px-2 py-1 rounded',
+              filter === 'state' ? 'bg-blue-100 text-blue-700' : 'text-gray-600'
+            )}
+          >
+            State
+          </button>
+        </div>
       </div>
       {validationErrors.length > 0 && (
         <div className="border-b border-zinc-200 bg-red-50 p-2">
@@ -60,69 +107,54 @@ export default function VarsInspector({ vars, onChange }: Props) {
 
       {/* Scrollable content */}
       <div className="flex-1 overflow-y-auto overflow-x-hidden">
-        <div className="text-xs">
-          {groups.map((group) => (
-            <div key={group.title}>
-              <div className="bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-700 sticky top-0">
-                {group.title}
-              </div>
-              {group.vars.map((name) => (
-                <div
-                  key={name}
-                  className="flex items-center border-b border-gray-100 px-3 py-2 hover:bg-gray-50 cursor-pointer"
-                  onClick={() =>
-                    setEditingVar({ name, value: vars[name] ?? "" })
-                  }>
-                  <div className="flex-1 min-w-0">
-                    <div className="text-xs font-medium text-gray-700 truncate">
-                      {name}
-                    </div>
-                  </div>
-                  <div className="ml-2 text-xs text-gray-600 truncate max-w-[120px]">
-                    {vars[name] !== undefined ? String(vars[name]) : "Not set"}
-                  </div>
-                </div>
-              ))}
+        {Object.entries(groupedVars).map(([category, variables]) => (
+          <div key={category} className="text-xs">
+            <div className="bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-700 sticky top-0">
+              {categoryTitles[category as keyof typeof categoryTitles]}
             </div>
-          ))}
-        </div>
+            {variables.map(({ key, ...meta }) => (
+              <VariableRow
+                key={key}
+                name={key}
+                value={vars[key]}
+                metadata={meta}
+                onEdit={() => setEditingVar({ name: key, value: vars[key] ?? "" })}
+              />
+            ))}
+          </div>
+        ))}
       </div>
 
       <Dialog open={!!editingVar} onClose={() => setEditingVar(null)}>
         <DialogTitle>Edit Variable</DialogTitle>
         <DialogDescription>
-          Update the value for{" "}
+          Update the value for{' '}
           <code className="font-mono">{editingVar?.name}</code>
         </DialogDescription>
         <DialogBody>
           <Field>
             <Label>Value</Label>
-            {WORKFLOW_VARIABLES[editingVar?.name as VarName] === "boolean" ?
+            {WORKFLOW_VARIABLES[editingVar?.name as VarName].type === 'boolean' ? (
               <Switch
-                checked={
-                  editingVar?.value === true || editingVar?.value === "true"
-                }
+                checked={editingVar?.value === true || editingVar?.value === 'true'}
                 onChange={(checked) =>
-                  setEditingVar((prev) =>
-                    prev ? { ...prev, value: checked } : null
-                  )
+                  setEditingVar((prev) => (prev ? { ...prev, value: checked } : null))
                 }
               />
-            : <Input
-                value={String(editingVar?.value || "")}
+            ) : (
+              <Input
+                value={String(editingVar?.value || '')}
                 onChange={(e) =>
                   setEditingVar((prev) =>
                     prev ? { ...prev, value: e.target.value } : null
                   )
                 }
               />
-            }
+            )}
           </Field>
         </DialogBody>
         <DialogActions>
-          <Button plain onClick={() => setEditingVar(null)}>
-            Cancel
-          </Button>
+          <Button plain onClick={() => setEditingVar(null)}>Cancel</Button>
           <Button color="blue" onClick={handleSave}>
             Save
           </Button>
@@ -130,4 +162,48 @@ export default function VarsInspector({ vars, onChange }: Props) {
       </Dialog>
     </div>
   );
+}
+
+function VariableRow({ name, value, metadata, onEdit }: {
+  name: VarName;
+  value: unknown;
+  metadata: VariableMetadata;
+  onEdit(): void;
+}) {
+  const relationships = [] as string[];
+  if (metadata.producedBy) relationships.push(`↘ from ${metadata.producedBy}`);
+  if (metadata.consumedBy?.length)
+    relationships.push(`↗ to ${metadata.consumedBy.join(', ')}`);
+
+  return (
+    <div
+      className="flex items-center border-b border-gray-100 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+      onClick={onEdit}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <div className="text-xs font-medium text-gray-700 truncate">
+            {camelToTitle(name)}
+          </div>
+          {metadata.configurable && (
+            <EditIcon className="h-3 w-3 text-gray-400" />
+          )}
+        </div>
+        {relationships.length > 0 && (
+          <div className="text-xs text-gray-500 mt-0.5">
+            {relationships.join(' ')}
+          </div>
+        )}
+      </div>
+      <div className="ml-2 text-xs text-gray-600 truncate max-w-[120px]">
+        {value !== undefined ? String(value) : 'Not set'}
+      </div>
+    </div>
+  );
+}
+
+function camelToTitle(str: string): string {
+  return str
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (c) => c.toUpperCase());
 }

--- a/app/components/WorkflowClient.tsx
+++ b/app/components/WorkflowClient.tsx
@@ -210,6 +210,7 @@ export default function WorkflowClient({ steps }: Props) {
                 onExecute={handleExecute}
                 onUndo={handleUndo}
                 onForce={handleForce}
+                onVarChange={(k, v) => updateVars({ [k]: v } as Partial<WorkflowVars>)}
               />
             </div>
           ))}

--- a/app/components/step-card/StepVariables.tsx
+++ b/app/components/step-card/StepVariables.tsx
@@ -1,0 +1,93 @@
+import { WORKFLOW_VARIABLES, VariableMetadata } from "@/lib/workflow/variables";
+import { StepIdValue, VarName, WorkflowVars } from "@/types";
+import { Input } from "../ui/input";
+
+interface StepVariablesProps {
+  stepId: StepIdValue;
+  vars: Partial<WorkflowVars>;
+  onChange: (key: VarName, value: unknown) => void;
+}
+
+function camelToTitle(str: string): string {
+  return str
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+export function StepVariables({ stepId, vars, onChange }: StepVariablesProps) {
+  const stepVars = (Object.entries(WORKFLOW_VARIABLES) as Array<[
+    VarName,
+    VariableMetadata
+  ]>)
+    .filter(
+      ([, meta]) =>
+        meta.consumedBy?.includes(stepId) || meta.producedBy === stepId
+    )
+    .map(([key, meta]) => ({ key: key as VarName, ...meta }));
+
+  if (stepVars.length === 0) return null;
+
+  return (
+    <div className="mt-4 space-y-3">
+      <h4 className="text-sm font-medium text-gray-700">Variables</h4>
+      {stepVars.map(({ key, ...meta }) => {
+        const isProducer = meta.producedBy === stepId;
+        const isShared =
+          (meta.consumedBy?.length || 0) > 1 ||
+          (meta.consumedBy && meta.producedBy);
+        return (
+          <div key={key} className="relative">
+            {isShared && (
+              <div className="absolute -left-2 top-2">
+                <div className="group relative">
+                  <svg
+                    className="h-4 w-4 text-blue-500"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z" />
+                  </svg>
+                  <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block">
+                    <div className="bg-gray-900 text-white text-xs rounded py-1 px-2 whitespace-nowrap">
+                      Shared with: {meta.consumedBy?.filter((id) => id !== stepId).join(', ')}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+            <div className="pl-6">
+              <div className="flex items-center gap-2">
+                <label className="text-sm font-medium text-gray-600">
+                  {camelToTitle(key)}
+                </label>
+                {isProducer && (
+                  <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded">
+                    Provides
+                  </span>
+                )}
+              </div>
+              {meta.configurable && !vars[key] ? (
+                <Input
+                  value={typeof vars[key] === 'string' ? vars[key] : ''}
+                  onChange={(e) => onChange(key, e.target.value)}
+                  placeholder={meta.description}
+                  className="mt-1"
+                />
+              ) : (
+                <div className="mt-1 text-sm text-gray-500">
+                  {vars[key] ? (
+                    <code className="bg-gray-100 px-1 py-0.5 rounded">
+                      {meta.sensitive ? '••••••••' : String(vars[key])}
+                    </code>
+                  ) : (
+                    <span className="italic">Not set</span>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/constants.ts
+++ b/constants.ts
@@ -75,6 +75,10 @@ export const ApiEndpoint = {
   }
 };
 
+export const OrgUnit = {
+  RootPath: "/"
+} as const;
+
 export const TemplateId = {
   GoogleWorkspaceConnector: "01303a13-8322-4e06-bee5-80d612907131",
   GoogleWorkspaceSaml: "8b1025e4-1dd2-430b-a150-2ef79cd700f5"

--- a/lib/workflow/variables.ts
+++ b/lib/workflow/variables.ts
@@ -2,90 +2,209 @@
  * Single source of truth for all workflow variables.
  * To add a new variable, just add it here.
  */
+
+import { StepId } from "./step-ids";
+import type { StepIdValue } from "./step-ids";
+
+export interface VariableMetadata {
+  type: "string" | "boolean";
+  category: "auth" | "domain" | "config" | "state";
+  description?: string;
+  producedBy?: StepIdValue;
+  consumedBy?: StepIdValue[];
+  configurable?: boolean;
+  sensitive?: boolean;
+}
+
 export const WORKFLOW_VARIABLES = {
-  // Tokens
-  googleAccessToken: "string",
-  msGraphToken: "string",
-
-  // Domain
-  primaryDomain: "string",
-  isDomainVerified: "boolean",
-  verificationToken: "string",
-
-  // Configuration variables
-  automationOuName: "string",
-  automationOuPath: "string",
-  provisioningUserPrefix: "string",
-  adminRoleName: "string",
-  samlProfileDisplayName: "string",
-  provisioningAppDisplayName: "string",
-  ssoAppDisplayName: "string",
-  claimsPolicyDisplayName: "string",
-
-  // Service account
-  provisioningUserId: "string",
-  provisioningUserEmail: "string",
-  provisioningUserPrefix: "string",
-  generatedPassword: "string",
-
-  // Roles
-  adminRoleId: "string",
-  directoryServiceId: "string",
-
-  // Microsoft apps
-  ssoServicePrincipalId: "string",
-  provisioningServicePrincipalId: "string",
-  ssoAppId: "string",
-
-  // SAML
-  samlProfileId: "string",
-  entityId: "string",
-  acsUrl: "string",
-
-  // Policy
-  claimsPolicyId: "string"
-} as const;
-
-export const WORKFLOW_VAR_GROUPS = [
-  { title: "Tokens", vars: ["googleAccessToken", "msGraphToken"] },
-  {
-    title: "Domain",
-    vars: ["primaryDomain", "isDomainVerified", "verificationToken"]
-  },
-  {
-    title: "Configuration",
-    vars: [
-      "automationOuName",
-      "automationOuPath",
-      "provisioningUserPrefix",
-      "adminRoleName",
-      "samlProfileDisplayName",
-      "provisioningAppDisplayName",
-      "ssoAppDisplayName",
-      "claimsPolicyDisplayName"
+  googleAccessToken: {
+    type: "string",
+    category: "auth",
+    description: "Google OAuth access token",
+    sensitive: true,
+    consumedBy: [
+      StepId.VerifyPrimaryDomain,
+      StepId.CreateAutomationOU,
+      StepId.CreateServiceUser,
+      StepId.CreateAdminRoleAndAssignUser,
+      StepId.ConfigureGoogleSamlProfile,
+      StepId.CompleteGoogleSsoSetup,
+      StepId.AssignUsersToSso
     ]
   },
-  {
-    title: "Service Account",
-    vars: [
-      "provisioningUserId",
-      "provisioningUserEmail",
-      "provisioningUserPrefix",
-      "generatedPassword"
+  msGraphToken: {
+    type: "string",
+    category: "auth",
+    description: "Microsoft Graph access token",
+    sensitive: true,
+    consumedBy: [
+      StepId.CreateMicrosoftApps,
+      StepId.ConfigureMicrosoftSyncAndSso,
+      StepId.SetupMicrosoftClaimsPolicy,
+      StepId.CompleteGoogleSsoSetup
     ]
   },
-  { title: "Roles", vars: ["adminRoleId", "directoryServiceId"] },
-  {
-    title: "Microsoft Apps",
-    vars: [
-      "ssoServicePrincipalId",
-      "provisioningServicePrincipalId",
-      "ssoAppId"
+  primaryDomain: {
+    type: "string",
+    category: "domain",
+    description: "Primary Google Workspace domain",
+    producedBy: StepId.VerifyPrimaryDomain,
+    consumedBy: [StepId.CreateServiceUser]
+  },
+  isDomainVerified: {
+    type: "boolean",
+    category: "domain",
+    description: "Whether domain is verified",
+    producedBy: StepId.VerifyPrimaryDomain,
+    consumedBy: [
+      StepId.CreateAutomationOU,
+      StepId.CreateServiceUser,
+      StepId.CreateAdminRoleAndAssignUser,
+      StepId.ConfigureGoogleSamlProfile,
+      StepId.AssignUsersToSso
     ]
   },
-  { title: "SAML", vars: ["samlProfileId", "entityId", "acsUrl"] },
-  { title: "Policy", vars: ["claimsPolicyId"] }
-] as const;
+  verificationToken: {
+    type: "string",
+    category: "domain",
+    description: "DNS verification token",
+    producedBy: StepId.VerifyPrimaryDomain
+  },
+  automationOuName: {
+    type: "string",
+    category: "config",
+    description: "Name for the automation OU",
+    consumedBy: [StepId.CreateAutomationOU],
+    configurable: true
+  },
+  automationOuPath: {
+    type: "string",
+    category: "config",
+    description: "Path of the automation OU",
+    consumedBy: [StepId.CreateAutomationOU, StepId.CreateServiceUser],
+    configurable: true
+  },
+  provisioningUserPrefix: {
+    type: "string",
+    category: "config",
+    description: "Prefix for provisioning user email",
+    consumedBy: [StepId.CreateServiceUser],
+    configurable: true
+  },
+  adminRoleName: {
+    type: "string",
+    category: "config",
+    description: "Name of the custom admin role",
+    consumedBy: [StepId.CreateAdminRoleAndAssignUser],
+    configurable: true
+  },
+  samlProfileDisplayName: {
+    type: "string",
+    category: "config",
+    description: "Display name for SAML profile",
+    consumedBy: [StepId.ConfigureGoogleSamlProfile],
+    configurable: true
+  },
+  provisioningAppDisplayName: {
+    type: "string",
+    category: "config",
+    description: "Display name for provisioning app",
+    consumedBy: [StepId.CreateMicrosoftApps],
+    configurable: true
+  },
+  ssoAppDisplayName: {
+    type: "string",
+    category: "config",
+    description: "Display name for SSO app",
+    consumedBy: [StepId.CreateMicrosoftApps],
+    configurable: true
+  },
+  claimsPolicyDisplayName: {
+    type: "string",
+    category: "config",
+    description: "Display name for claims policy",
+    consumedBy: [StepId.SetupMicrosoftClaimsPolicy],
+    configurable: true
+  },
+  provisioningUserId: {
+    type: "string",
+    category: "state",
+    description: "Google user ID for provisioning account",
+    producedBy: StepId.CreateServiceUser,
+    consumedBy: [StepId.CreateAdminRoleAndAssignUser]
+  },
+  provisioningUserEmail: {
+    type: "string",
+    category: "state",
+    description: "Email for provisioning account",
+    producedBy: StepId.CreateServiceUser
+  },
+  generatedPassword: {
+    type: "string",
+    category: "state",
+    description: "Password for provisioning account",
+    producedBy: StepId.CreateServiceUser,
+    consumedBy: [StepId.ConfigureMicrosoftSyncAndSso],
+    sensitive: true
+  },
+  adminRoleId: {
+    type: "string",
+    category: "state",
+    description: "Custom admin role ID",
+    producedBy: StepId.CreateAdminRoleAndAssignUser
+  },
+  directoryServiceId: {
+    type: "string",
+    category: "state",
+    description: "Directory service ID",
+    producedBy: StepId.CreateAdminRoleAndAssignUser
+  },
+  ssoServicePrincipalId: {
+    type: "string",
+    category: "state",
+    description: "Service principal for SSO app",
+    producedBy: StepId.CreateMicrosoftApps,
+    consumedBy: [StepId.SetupMicrosoftClaimsPolicy, StepId.CompleteGoogleSsoSetup]
+  },
+  provisioningServicePrincipalId: {
+    type: "string",
+    category: "state",
+    description: "Service principal for provisioning app",
+    producedBy: StepId.CreateMicrosoftApps,
+    consumedBy: [StepId.ConfigureMicrosoftSyncAndSso]
+  },
+  ssoAppId: {
+    type: "string",
+    category: "state",
+    description: "Application ID for SSO app",
+    producedBy: StepId.CreateMicrosoftApps
+  },
+  samlProfileId: {
+    type: "string",
+    category: "state",
+    description: "SAML profile identifier",
+    producedBy: StepId.ConfigureGoogleSamlProfile,
+    consumedBy: [StepId.CompleteGoogleSsoSetup, StepId.AssignUsersToSso]
+  },
+  entityId: {
+    type: "string",
+    category: "state",
+    description: "Service provider entityId",
+    producedBy: StepId.ConfigureGoogleSamlProfile
+  },
+  acsUrl: {
+    type: "string",
+    category: "state",
+    description: "Assertion consumer service URL",
+    producedBy: StepId.ConfigureGoogleSamlProfile
+  },
+  claimsPolicyId: {
+    type: "string",
+    category: "state",
+    description: "Claims policy identifier",
+    producedBy: StepId.SetupMicrosoftClaimsPolicy
+  }
+} as const satisfies Record<string, VariableMetadata>;
 
 // Auto-generate Var enum with PascalCase keys
 function toPascalCase<S extends string>(str: S): Capitalize<S> {
@@ -101,11 +220,9 @@ export const Var = (
 
 // Auto-generate WorkflowVars type
 export type WorkflowVars = {
-  [K in keyof typeof WORKFLOW_VARIABLES]: (typeof WORKFLOW_VARIABLES)[K] extends (
-    "string"
-  ) ?
-    string
-  : boolean;
+  [K in keyof typeof WORKFLOW_VARIABLES]: typeof WORKFLOW_VARIABLES[K]["type"] extends "string"
+    ? string
+    : boolean;
 };
 
 // Export useful types


### PR DESCRIPTION
## Summary
- track workflow variable metadata including producers/consumers
- display step specific variables with inline editing
- filter variables drawer by category
- wire up variable editing through StepCard
- export missing `OrgUnit` constant

## Testing
- `npx eslint . --ext .ts,.tsx`
- `npx tsc -p tsconfig.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685372a06ea08322bf390394462ed900