### PR TITLE
Migrate workflow steps to new builder

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,7 +34,7 @@ const eslintConfig = [
     files: ["lib/workflow/steps/*.ts"],
     rules: {
       // 1. Step structure enforcement
-      "workflow/must-export-create-step": "error",
+      "workflow/must-export-create-step": "off",
       "workflow/must-destructure-context": "error",
       "workflow/must-use-try-catch": "error",
       "workflow/must-call-required-callbacks": "error",

--- a/lib/workflow/step-builder.ts
+++ b/lib/workflow/step-builder.ts
@@ -1,8 +1,3 @@
-/**
- * Fluent builder utility for creating workflow steps with simplified context
- * helpers. The builder abstracts variable handling and HTTP helpers so that
- * individual step files can focus on their business logic.
- */
 import {
   StepCheckContext,
   StepDefinition,
@@ -15,72 +10,102 @@ import {
 import { z } from "zod";
 import { createStep } from "./create-step";
 
-/**
- * Describes the chainable builder returned by {@link defineStep}. Each method
- * mutates internal state and returns the builder for further configuration.
- */
 interface StepBuilder<
   TData extends Partial<WorkflowVars> = Partial<WorkflowVars>
 > {
   requires(...vars: VarName[]): StepBuilder<TData>;
   provides(...vars: VarName[]): StepBuilder<TData>;
   check(
-    fn: (ctx: SimplifiedCheckContext<TData>) => Promise<void>
+    fn: (ctx: BuilderCheckContext<TData>) => Promise<void>
   ): StepBuilder<TData>;
   execute(
-    fn: (ctx: SimplifiedExecuteContext<TData>) => Promise<void>
+    fn: (ctx: BuilderExecuteContext<TData>) => Promise<void>
   ): StepBuilder<TData>;
-  undo(fn: (ctx: SimplifiedUndoContext) => Promise<void>): StepBuilder<TData>;
-  build(): StepDefinition;
-}
-
-interface SimplifiedCheckContext<T> extends Omit<StepCheckContext<T>, "vars"> {
-  vars: {
-    get<K extends VarName>(key: K): WorkflowVars[K] | undefined;
-    require<K extends VarName>(key: K): NonNullable<WorkflowVars[K]>;
-    build(template: string): string;
-  };
-  google: {
-    get<R>(path: string, schema: z.ZodSchema<R>): Promise<R>;
-    post<R>(path: string, schema: z.ZodSchema<R>, body: unknown): Promise<R>;
-  };
-  microsoft: {
-    get<R>(path: string, schema: z.ZodSchema<R>): Promise<R>;
-    post<R>(path: string, schema: z.ZodSchema<R>, body: unknown): Promise<R>;
+  undo(fn: (ctx: BuilderUndoContext) => Promise<void>): StepBuilder<TData>;
+  build(): StepDefinition & {
+    check(ctx: StepCheckContext<TData>): Promise<void>;
+    execute(ctx: StepExecuteContext<TData>): Promise<void>;
+    undo?(ctx: StepUndoContext): Promise<void>;
   };
 }
 
-interface SimplifiedExecuteContext<T>
-  extends Omit<StepExecuteContext<T>, "vars" | "markSucceeded"> {
-  vars: SimplifiedCheckContext<T>["vars"];
-  google: SimplifiedCheckContext<T>["google"];
-  microsoft: SimplifiedCheckContext<T>["microsoft"];
+interface HttpClient {
+  get<R>(
+    url: string,
+    schema: z.ZodSchema<R>,
+    options?: { flatten?: boolean }
+  ): Promise<R>;
+  post<R>(
+    url: string,
+    schema: z.ZodSchema<R>,
+    body?: unknown,
+    options?: { flatten?: boolean }
+  ): Promise<R>;
+  put<R>(
+    url: string,
+    schema: z.ZodSchema<R>,
+    body?: unknown,
+    options?: { flatten?: boolean }
+  ): Promise<R>;
+  patch<R>(
+    url: string,
+    schema: z.ZodSchema<R>,
+    body?: unknown,
+    options?: { flatten?: boolean }
+  ): Promise<R>;
+  delete<R>(
+    url: string,
+    schema: z.ZodSchema<R>,
+    options?: { flatten?: boolean }
+  ): Promise<R>;
+}
+
+interface VarStore {
+  get<K extends VarName>(key: K): WorkflowVars[K] | undefined;
+  require<K extends VarName>(key: K): NonNullable<WorkflowVars[K]>;
+  build(template: string): string;
+}
+
+interface BuilderCheckContext<T> {
+  vars: VarStore;
+  google: HttpClient;
+  microsoft: HttpClient;
+  log: StepCheckContext<T>["log"];
+  markComplete: StepCheckContext<T>["markComplete"];
+  markIncomplete: StepCheckContext<T>["markIncomplete"];
+  markCheckFailed: StepCheckContext<T>["markCheckFailed"];
+}
+
+interface BuilderExecuteContext<T> {
+  vars: VarStore;
+  google: HttpClient;
+  microsoft: HttpClient;
+  checkData: T;
+  log: StepExecuteContext<T>["log"];
   output(vars: Partial<WorkflowVars>): void;
+  markFailed: StepExecuteContext<T>["markFailed"];
+  markPending: StepExecuteContext<T>["markPending"];
 }
 
-interface SimplifiedUndoContext extends Omit<StepUndoContext, "vars"> {
-  vars: SimplifiedCheckContext<unknown>["vars"];
-  google: SimplifiedCheckContext<unknown>["google"];
-  microsoft: SimplifiedCheckContext<unknown>["microsoft"];
+interface BuilderUndoContext {
+  vars: VarStore;
+  google: HttpClient;
+  microsoft: HttpClient;
+  log: StepUndoContext["log"];
+  markReverted: StepUndoContext["markReverted"];
+  markFailed: StepUndoContext["markFailed"];
 }
 
-/**
- * Entry point for creating a new workflow step. Callers chain together
- * requirements, output variables and handler functions before finally invoking
- * {@link StepBuilder.build} to produce a `StepDefinition` compatible with the
- * engine.
- */
 export function defineStep<
   TData extends Partial<WorkflowVars> = Partial<WorkflowVars>
 >(id: StepIdValue): StepBuilder<TData> {
   let requires: VarName[] = [];
   let provides: VarName[] = [];
-  let checkFn: ((ctx: SimplifiedCheckContext<TData>) => Promise<void>) | null =
+  let checkFn: ((ctx: BuilderCheckContext<TData>) => Promise<void>) | null =
     null;
-  let executeFn:
-    | ((ctx: SimplifiedExecuteContext<TData>) => Promise<void>)
-    | null = null;
-  let undoFn: ((ctx: SimplifiedUndoContext) => Promise<void>) | null = null;
+  let executeFn: ((ctx: BuilderExecuteContext<TData>) => Promise<void>) | null =
+    null;
+  let undoFn: ((ctx: BuilderUndoContext) => Promise<void>) | null = null;
 
   const builder: StepBuilder<TData> = {
     requires(...vars: VarName[]) {
@@ -115,31 +140,30 @@ export function defineStep<
         );
       }
 
-      return createStep<TData, typeof requires, typeof provides>({
+      return createStep<TData>({
         id,
         requires,
         provides,
 
-        async check(ctx) {
-          const simplified = createSimplifiedContext(ctx);
-          await checkFn!(
-            simplified as unknown as SimplifiedCheckContext<TData>
-          );
+        async check(originalCtx) {
+          const ctx = wrapContext(originalCtx);
+          await checkFn!(ctx);
         },
 
-        async execute(ctx) {
-          const simplified = {
-            ...createSimplifiedContext(ctx),
-            checkData: ctx.checkData,
-            output: (vars: Partial<WorkflowVars>) => ctx.markSucceeded(vars)
-          } as SimplifiedExecuteContext<TData>;
-          await executeFn!(simplified);
+        async execute(originalCtx) {
+          const ctx = {
+            ...wrapContext(originalCtx),
+            checkData: originalCtx.checkData,
+            output: (vars: Partial<WorkflowVars>) =>
+              originalCtx.markSucceeded(vars)
+          };
+          await executeFn!(ctx);
         },
 
-        async undo(ctx) {
+        async undo(originalCtx) {
           if (undoFn) {
-            const simplified = createSimplifiedContext(ctx);
-            await undoFn(simplified as SimplifiedUndoContext);
+            const ctx = wrapContext(originalCtx);
+            await undoFn(ctx);
           }
         }
       });
@@ -149,54 +173,90 @@ export function defineStep<
   return builder;
 }
 
-/**
- * Convert the verbose engine context into a smaller set of helpers used by
- * steps defined via {@link defineStep}. This keeps step implementations tidy
- * while still allowing access to the underlying fetch utilities.
- */
-interface BaseContext {
-  vars: Partial<WorkflowVars>;
-  fetchGoogle: StepCheckContext<unknown>["fetchGoogle"];
-  fetchMicrosoft: StepCheckContext<unknown>["fetchMicrosoft"];
+function createHttpClient(
+  fetchFn: <R>(
+    url: string,
+    schema: z.ZodSchema<R>,
+    init?: RequestInit & { flatten?: boolean }
+  ) => Promise<R>
+): HttpClient {
+  return {
+    get: (url, schema, options) =>
+      fetchFn(url, schema, { method: "GET", ...options }),
+
+    post: (url, schema, body, options) =>
+      fetchFn(url, schema, {
+        method: "POST",
+        body: body ? JSON.stringify(body) : undefined,
+        ...options
+      }),
+
+    put: (url, schema, body, options) =>
+      fetchFn(url, schema, {
+        method: "PUT",
+        body: body ? JSON.stringify(body) : undefined,
+        ...options
+      }),
+
+    patch: (url, schema, body, options) =>
+      fetchFn(url, schema, {
+        method: "PATCH",
+        body: body ? JSON.stringify(body) : undefined,
+        ...options
+      }),
+
+    delete: (url, schema, options) =>
+      fetchFn(url, schema, { method: "DELETE", ...options })
+  };
 }
 
-function createSimplifiedContext(ctx: BaseContext) {
+function createVarStore(vars: Partial<WorkflowVars>): VarStore {
   return {
-    ...ctx,
-    vars: {
-      get: <K extends VarName>(key: K) => ctx.vars[key],
-      require: <K extends VarName>(key: K) => {
-        const value = ctx.vars[key];
+    get: <K extends VarName>(key: K) => vars[key],
+    require: <K extends VarName>(key: K) => {
+      const value = vars[key];
+      if (value === undefined)
+        throw new Error(`Required variable ${key} is missing`);
+      return value;
+    },
+    build: (template: string) => {
+      return template.replace(/\{(\w+)\}/g, (_, key) => {
+        const value = vars[key as VarName];
         if (value === undefined)
-          throw new Error(`Required variable ${key} is missing`);
-        return value;
-      },
-      build: (template: string) => {
-        return template.replace(/\{(\w+)\}/g, (_, key) => {
-          const value = ctx.vars[key as VarName];
-          if (value === undefined)
-            throw new Error(`Template variable ${key} is missing`);
-          return String(value);
-        });
-      }
-    },
-    google: {
-      get: (path: string, schema: z.ZodSchema<unknown>) =>
-        ctx.fetchGoogle(path, schema),
-      post: (path: string, schema: z.ZodSchema<unknown>, body: unknown) =>
-        ctx.fetchGoogle(path, schema, {
-          method: "POST",
-          body: JSON.stringify(body)
-        })
-    },
-    microsoft: {
-      get: (path: string, schema: z.ZodSchema<unknown>) =>
-        ctx.fetchMicrosoft(path, schema),
-      post: (path: string, schema: z.ZodSchema<unknown>, body: unknown) =>
-        ctx.fetchMicrosoft(path, schema, {
-          method: "POST",
-          body: JSON.stringify(body)
-        })
+          throw new Error(`Template variable ${key} is missing`);
+        return String(value);
+      });
     }
   };
+}
+
+function wrapContext<C extends {
+  fetchGoogle: StepCheckContext<unknown>["fetchGoogle"];
+  fetchMicrosoft: StepCheckContext<unknown>["fetchMicrosoft"];
+  vars: Partial<WorkflowVars>;
+}>(ctx: C): Omit<C, "fetchGoogle" | "fetchMicrosoft" | "vars"> & {
+  vars: VarStore;
+  google: HttpClient;
+  microsoft: HttpClient;
+} {
+  const { fetchGoogle, fetchMicrosoft, vars, ...rest } = ctx;
+
+  return {
+    ...rest,
+    vars: createVarStore(vars),
+    google: createHttpClient(fetchGoogle),
+    microsoft: createHttpClient(fetchMicrosoft)
+  };
+}
+
+// Keep getVar for migration purposes only
+export function getVar<K extends VarName>(
+  vars: Partial<WorkflowVars>,
+  key: K
+): WorkflowVars[K] {
+  const value = vars[key];
+  if (value === undefined) {
+    throw new Error(`Required variable ${key} is not available`);
+  }
+  return value;
 }

--- a/lib/workflow/steps/configure-google-saml-profile.ts
+++ b/lib/workflow/steps/configure-google-saml-profile.ts
@@ -2,16 +2,15 @@ import { ApiEndpoint } from "@/constants";
 import { EmptyResponseSchema, isNotFoundError } from "@/lib/workflow/utils";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
-import { createStep, getVar } from "../create-step";
+import { defineStep } from "../step-builder";
 
-export default createStep({
-  id: StepId.ConfigureGoogleSamlProfile,
-  requires: [
+export default defineStep(StepId.ConfigureGoogleSamlProfile)
+  .requires(
     Var.GoogleAccessToken,
     Var.IsDomainVerified,
     Var.SamlProfileDisplayName
-  ],
-  provides: [Var.SamlProfileId, Var.EntityId, Var.AcsUrl],
+  )
+  .provides(Var.SamlProfileId, Var.EntityId, Var.AcsUrl)
 
   /**
    * GET https://cloudidentity.googleapis.com/v1/inboundSamlSsoProfiles
@@ -30,59 +29,49 @@ export default createStep({
    * { "inboundSamlSsoProfiles": [] }
    */
 
-  async check({
-    fetchGoogle,
-    markComplete,
-    markIncomplete,
-    markCheckFailed,
-    log
-  }) {
-    try {
-      const ProfilesSchema = z.object({
-        inboundSamlSsoProfiles: z
-          .array(
-            z.object({
-              name: z.string(),
-              spConfig: z.object({
-                entityId: z.string(),
-                assertionConsumerServiceUri: z.string()
+  .check(
+    async ({ google, markComplete, markIncomplete, markCheckFailed, log }) => {
+      try {
+        const ProfilesSchema = z.object({
+          inboundSamlSsoProfiles: z
+            .array(
+              z.object({
+                name: z.string(),
+                spConfig: z.object({
+                  entityId: z.string(),
+                  assertionConsumerServiceUri: z.string()
+                })
               })
-            })
-          )
-          .optional()
-      });
-
-      const { inboundSamlSsoProfiles = [] } = await fetchGoogle(
-        ApiEndpoint.Google.SsoProfiles,
-        ProfilesSchema,
-        { flatten: true }
-      );
-
-      if (inboundSamlSsoProfiles.length > 0) {
-        const profile = inboundSamlSsoProfiles[0];
-        log(LogLevel.Info, "SAML profile already exists");
-        markComplete({
-          samlProfileId: profile.name,
-          entityId: profile.spConfig.entityId,
-          acsUrl: profile.spConfig.assertionConsumerServiceUri
+            )
+            .optional()
         });
-      } else {
-        markIncomplete("SAML profile missing", {});
-      }
-    } catch (error) {
-      log(LogLevel.Error, "Failed to check SAML profiles", { error });
-      markCheckFailed(error instanceof Error ? error.message : "Check failed");
-    }
-  },
 
-  async execute({
-    vars,
-    fetchGoogle,
-    markSucceeded,
-    markFailed,
-    markPending,
-    log
-  }) {
+        const { inboundSamlSsoProfiles = [] } = await google.get(
+          ApiEndpoint.Google.SsoProfiles,
+          ProfilesSchema,
+          { flatten: true }
+        );
+
+        if (inboundSamlSsoProfiles.length > 0) {
+          const profile = inboundSamlSsoProfiles[0];
+          log(LogLevel.Info, "SAML profile already exists");
+          markComplete({
+            samlProfileId: profile.name,
+            entityId: profile.spConfig.entityId,
+            acsUrl: profile.spConfig.assertionConsumerServiceUri
+          });
+        } else {
+          markIncomplete("SAML profile missing", {});
+        }
+      } catch (error) {
+        log(LogLevel.Error, "Failed to check SAML profiles", { error });
+        markCheckFailed(
+          error instanceof Error ? error.message : "Check failed"
+        );
+      }
+    }
+  )
+  .execute(async ({ vars, google, output, markFailed, markPending, log }) => {
     /**
      * POST https://cloudidentity.googleapis.com/v1/customers/my_customer/inboundSamlSsoProfiles
      * {
@@ -126,12 +115,9 @@ export default createStep({
         "/inboundSamlSsoProfiles",
         "/customers/my_customer/inboundSamlSsoProfiles"
       )}`;
-      const op = await fetchGoogle(createUrl, opSchema, {
-        method: "POST",
-        body: JSON.stringify({
-          displayName: getVar(vars, Var.SamlProfileDisplayName),
-          idpConfig: { entityId: "", singleSignOnServiceUri: "" }
-        })
+      const op = await google.post(createUrl, opSchema, {
+        displayName: vars.require("samlProfileDisplayName"),
+        idpConfig: { entityId: "", singleSignOnServiceUri: "" }
       });
 
       if (!op.done) {
@@ -152,27 +138,26 @@ export default createStep({
         return;
       }
 
-      markSucceeded({
-        [Var.SamlProfileId]: profile.name,
-        [Var.EntityId]: profile.spConfig.entityId,
-        [Var.AcsUrl]: profile.spConfig.assertionConsumerServiceUri
+      output({
+        samlProfileId: profile.name,
+        entityId: profile.spConfig.entityId,
+        acsUrl: profile.spConfig.assertionConsumerServiceUri
       });
     } catch (error) {
       log(LogLevel.Error, "Failed to create SAML profile", { error });
       markFailed(error instanceof Error ? error.message : "Execute failed");
     }
-  },
-  undo: async ({ vars, fetchGoogle, markReverted, markFailed, log }) => {
+  })
+  .undo(async ({ vars, google, markReverted, markFailed, log }) => {
     try {
-      const id = vars[Var.SamlProfileId] as string | undefined;
+      const id = vars.get("samlProfileId");
       if (!id) {
         markFailed("Missing samlProfileId");
         return;
       }
-      await fetchGoogle(
+      await google.delete(
         `${ApiEndpoint.Google.SsoProfiles}/${encodeURIComponent(id)}`,
-        EmptyResponseSchema,
-        { method: "DELETE" }
+        EmptyResponseSchema
       );
       markReverted();
     } catch (error) {
@@ -183,5 +168,5 @@ export default createStep({
         markFailed(error instanceof Error ? error.message : "Undo failed");
       }
     }
-  }
-});
+  })
+  .build();

--- a/lib/workflow/steps/create-service-user.ts
+++ b/lib/workflow/steps/create-service-user.ts
@@ -9,22 +9,21 @@ import {
 import { LogLevel, StepId, Var } from "@/types";
 import crypto from "crypto";
 import { z } from "zod";
-import { createStep, getVar } from "../create-step";
+import { defineStep } from "../step-builder";
 
-export default createStep({
-  id: StepId.CreateServiceUser,
-  requires: [
+export default defineStep(StepId.CreateServiceUser)
+  .requires(
     Var.GoogleAccessToken,
     Var.IsDomainVerified,
     Var.PrimaryDomain,
     Var.ProvisioningUserPrefix,
     Var.AutomationOuPath
-  ],
-  provides: [
+  )
+  .provides(
     Var.ProvisioningUserId,
     Var.ProvisioningUserEmail,
     Var.GeneratedPassword
-  ],
+  )
 
   /**
    * GET https://admin.googleapis.com/admin/directory/v1/users/azuread-provisioning@{primaryDomain}
@@ -39,138 +38,138 @@ export default createStep({
    * { "error": { "code": 404 } }
    */
 
-  async check({
-    vars,
-    fetchGoogle,
-    markComplete,
-    markIncomplete,
-    markCheckFailed,
-    log
-  }) {
-    try {
-      const domain = getVar(vars, Var.PrimaryDomain);
-      const prefix = getVar(vars, Var.ProvisioningUserPrefix);
+  .check(
+    async ({
+      vars,
+      google,
+      markComplete,
+      markIncomplete,
+      markCheckFailed,
+      log
+    }) => {
+      try {
+        const domain = vars.require("primaryDomain");
+        const prefix = vars.require("provisioningUserPrefix");
 
-      const UserSchema = z
-        .object({
-          id: z.string().optional(),
-          primaryEmail: z.string().optional(),
-          orgUnitPath: z.string().optional()
-        })
-        .passthrough();
-      const email = `${prefix}@${domain}`;
-      const url = `${ApiEndpoint.Google.Users}/${encodeURIComponent(email)}?fields=id,primaryEmail`;
-      const user = await fetchGoogle(url, UserSchema);
+        const UserSchema = z
+          .object({
+            id: z.string().optional(),
+            primaryEmail: z.string().optional(),
+            orgUnitPath: z.string().optional()
+          })
+          .passthrough();
+        const email = `${prefix}@${domain}`;
+        const url = `${ApiEndpoint.Google.Users}/${encodeURIComponent(email)}?fields=id,primaryEmail`;
+        const user = await google.get(url, UserSchema);
 
-      if (user.id && user.primaryEmail) {
-        log(LogLevel.Info, "Service user already exists");
-        markComplete({
-          provisioningUserId: user.id,
-          provisioningUserEmail: user.primaryEmail
-        });
-      } else {
-        log(LogLevel.Error, "Unexpected user response", { user });
-        markCheckFailed("Malformed user object returned");
-      }
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        markIncomplete("Service user missing", {});
-      } else {
-        log(LogLevel.Error, "Failed to check service user", { error });
-        markCheckFailed(
-          error instanceof Error ? error.message : "Failed to check user"
-        );
+        if (user.id && user.primaryEmail) {
+          log(LogLevel.Info, "Service user already exists");
+          markComplete({
+            provisioningUserId: user.id,
+            provisioningUserEmail: user.primaryEmail
+          });
+        } else {
+          log(LogLevel.Error, "Unexpected user response", { user });
+          markCheckFailed("Malformed user object returned");
+        }
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          markIncomplete("Service user missing", {});
+        } else {
+          log(LogLevel.Error, "Failed to check service user", { error });
+          markCheckFailed(
+            error instanceof Error ? error.message : "Failed to check user"
+          );
+        }
       }
     }
-  },
+  )
 
-  async execute({
-    vars,
-    fetchGoogle,
-    checkData: _checkData,
-    markSucceeded,
-    markFailed,
-    log
-  }) {
-    /**
-     * POST https://admin.googleapis.com/admin/directory/v1/users
-     * {
-     *   "primaryEmail": "azuread-provisioning@{primaryDomain}",
-     *   "name": { "givenName": "Microsoft", "familyName": "Provisioning" },
-     *   "password": "TempXXXX!",
-     *   "orgUnitPath": "/Automation"
-     * }
-     *
-     * Success response
-     *
-     * 201
-     * { "id": "...", "primaryEmail": "azuread-provisioning@cep-netnew.cc" }
-     *
-     * Conflict response
-     *
-     * 409
-     * { "error": { "message": "Entity already exists." } }
-     */
-    try {
-      const domain = getVar(vars, Var.PrimaryDomain);
-
-      const BYTES = 4;
-      const password = `Temp${crypto.randomBytes(BYTES).toString("hex")}!`;
-      const CreateSchema = z.object({
-        id: z.string(),
-        primaryEmail: z.string()
-      });
-
-      let user;
+  .execute(
+    async ({
+      vars,
+      google,
+      checkData: _checkData,
+      output,
+      markFailed,
+      log
+    }) => {
+      /**
+       * POST https://admin.googleapis.com/admin/directory/v1/users
+       * {
+       *   "primaryEmail": "azuread-provisioning@{primaryDomain}",
+       *   "name": { "givenName": "Microsoft", "familyName": "Provisioning" },
+       *   "password": "TempXXXX!",
+       *   "orgUnitPath": "/Automation"
+       * }
+       *
+       * Success response
+       *
+       * 201
+       * { "id": "...", "primaryEmail": "azuread-provisioning@cep-netnew.cc" }
+       *
+       * Conflict response
+       *
+       * 409
+       * { "error": { "message": "Entity already exists." } }
+       */
       try {
-        const prefix = getVar(vars, Var.ProvisioningUserPrefix);
-        const ouPath = getVar(vars, Var.AutomationOuPath);
-        user = await fetchGoogle(ApiEndpoint.Google.Users, CreateSchema, {
-          method: "POST",
-          body: JSON.stringify({
+        const domain = vars.require("primaryDomain");
+
+        const BYTES = 4;
+        const password = `Temp${crypto.randomBytes(BYTES).toString("hex")}!`;
+        const CreateSchema = z.object({
+          id: z.string(),
+          primaryEmail: z.string()
+        });
+
+        let user;
+        try {
+          const prefix = vars.require("provisioningUserPrefix");
+          const ouPath = vars.require("automationOuPath");
+          user = await google.post(ApiEndpoint.Google.Users, CreateSchema, {
             primaryEmail: `${prefix}@${domain}`,
             name: { givenName: "Microsoft", familyName: "Provisioning" },
             password,
             orgUnitPath: ouPath
-          })
+          });
+        } catch (error) {
+          if (isConflictError(error)) {
+            const fallbackEmail = `${vars.require("provisioningUserPrefix")}@${domain}`;
+            const getUrl = `${ApiEndpoint.Google.Users}/${encodeURIComponent(fallbackEmail)}?fields=id,primaryEmail`;
+            user = await google.get(getUrl, CreateSchema);
+
+            await google.put(
+              `${ApiEndpoint.Google.Users}/${user.id}`,
+              z.object({}),
+              { password }
+            );
+          } else {
+            throw error;
+          }
+        }
+
+        output({
+          provisioningUserId: user.id,
+          provisioningUserEmail: user.primaryEmail,
+          generatedPassword: password
         });
       } catch (error) {
-        if (isConflictError(error)) {
-          const fallbackEmail = `${getVar(vars, Var.ProvisioningUserPrefix)}@${domain}`;
-          const getUrl = `${ApiEndpoint.Google.Users}/${encodeURIComponent(fallbackEmail)}?fields=id,primaryEmail`;
-          user = await fetchGoogle(getUrl, CreateSchema);
-
-          await fetchGoogle(
-            `${ApiEndpoint.Google.Users}/${user.id}`,
-            z.object({}),
-            { method: "PUT", body: JSON.stringify({ password }) }
-          );
-        } else {
-          throw error;
-        }
+        log(LogLevel.Error, "Failed to create service user", { error });
+        markFailed(error instanceof Error ? error.message : "Create failed");
       }
-
-      markSucceeded({
-        [Var.ProvisioningUserId]: user.id,
-        [Var.ProvisioningUserEmail]: user.primaryEmail,
-        [Var.GeneratedPassword]: password
-      });
-    } catch (error) {
-      log(LogLevel.Error, "Failed to create service user", { error });
-      markFailed(error instanceof Error ? error.message : "Create failed");
     }
-  },
-  undo: async ({ vars, fetchGoogle, markReverted, markFailed, log }) => {
+  )
+  .undo(async ({ vars, google, markReverted, markFailed, log }) => {
     try {
-      const id = vars[Var.ProvisioningUserId] as string | undefined;
+      const id = vars.get("provisioningUserId");
       if (!id) {
         markFailed("Missing provisioning user id");
         return;
       }
-      await fetchGoogle(
+      await google.delete(
         `${ApiEndpoint.Google.Users}/${id}`,
-        EmptyResponseSchema,
-        { method: "DELETE" }
+        EmptyResponseSchema
       );
       markReverted();
     } catch (error) {
@@ -181,5 +180,5 @@ export default createStep({
         markFailed(error instanceof Error ? error.message : "Undo failed");
       }
     }
-  }
-});
+  })
+  .build();

--- a/lib/workflow/steps/test-sso-configuration.ts
+++ b/lib/workflow/steps/test-sso-configuration.ts
@@ -1,27 +1,25 @@
 import { StepId } from "@/types";
-import { createStep } from "../create-step";
+import { defineStep } from "../step-builder";
 
-export default createStep({
-  id: StepId.TestSsoConfiguration,
-  requires: [],
-  provides: [],
+export default defineStep(StepId.TestSsoConfiguration)
+  .requires()
+  .provides()
 
-  async check({ markIncomplete }) {
+  .check(async ({ markIncomplete }) => {
     try {
       markIncomplete("Manual test required", {});
     } catch {
       markIncomplete("Manual test required", {});
     }
-  },
-
-  async execute({ markPending }) {
+  })
+  .execute(async ({ markPending }) => {
     try {
       markPending("Complete login flow manually");
     } catch {
       markPending("Complete login flow manually");
     }
-  },
-  undo: async ({ markReverted }) => {
+  })
+  .undo(async ({ markReverted }) => {
     markReverted();
-  }
-});
+  })
+  .build();

--- a/lib/workflow/steps/verify-primary-domain.ts
+++ b/lib/workflow/steps/verify-primary-domain.ts
@@ -1,12 +1,11 @@
 import { ApiEndpoint } from "@/constants";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
-import { createStep } from "../create-step";
+import { defineStep } from "../step-builder";
 
-export default createStep({
-  id: StepId.VerifyPrimaryDomain,
-  requires: [Var.GoogleAccessToken],
-  provides: [Var.IsDomainVerified, Var.PrimaryDomain],
+export default defineStep(StepId.VerifyPrimaryDomain)
+  .requires(Var.GoogleAccessToken)
+  .provides(Var.IsDomainVerified, Var.PrimaryDomain)
 
   /**
    * GET https://admin.googleapis.com/admin/directory/v1/customer/my_customer/domains
@@ -27,146 +26,130 @@ export default createStep({
    * { "domains": [] }
    */
 
-  async check({
-    fetchGoogle,
-    markComplete,
-    markIncomplete,
-    markCheckFailed,
-    log
-  }) {
-    try {
-      const DomainsResponse = z.object({
-        domains: z.array(
-          z.object({
-            domainName: z.string(),
-            isPrimary: z.boolean(),
-            verified: z.boolean()
-          })
-        )
-      });
-
-      const { domains } = await fetchGoogle(
-        ApiEndpoint.Google.Domains,
-        DomainsResponse,
-        { flatten: true }
-      );
-
-      const primary = domains.find((d) => d.isPrimary);
-
-      if (primary?.verified) {
-        log(LogLevel.Info, "Primary domain already verified");
-        markComplete({
-          isDomainVerified: "true",
-          primaryDomain: primary.domainName
+  .check(
+    async ({ google, markComplete, markIncomplete, markCheckFailed, log }) => {
+      try {
+        const DomainsResponse = z.object({
+          domains: z.array(
+            z.object({
+              domainName: z.string(),
+              isPrimary: z.boolean(),
+              verified: z.boolean()
+            })
+          )
         });
-        return;
-      }
 
-      if (primary) {
-        const TokenSchema = z.object({
-          method: z.string(),
-          type: z.string(),
-          site: z.object({ type: z.string(), identifier: z.string() }),
-          token: z.string()
+        const { domains } = await google.get(
+          ApiEndpoint.Google.Domains,
+          DomainsResponse,
+          { flatten: true }
+        );
+
+        const primary = domains.find((d) => d.isPrimary);
+
+        if (primary?.verified) {
+          log(LogLevel.Info, "Primary domain already verified");
+          markComplete({
+            isDomainVerified: "true",
+            primaryDomain: primary.domainName
+          });
+          return;
+        }
+
+        if (primary) {
+          const TokenSchema = z.object({
+            method: z.string(),
+            type: z.string(),
+            site: z.object({ type: z.string(), identifier: z.string() }),
+            token: z.string()
+          });
+
+          try {
+            const verificationData = await google.post(
+              `${ApiEndpoint.Google.SiteVerification}/token`,
+              TokenSchema,
+              {
+                site: { type: "INET_DOMAIN", identifier: primary.domainName },
+                verificationMethod: "DNS_TXT"
+              }
+            );
+
+            markIncomplete("Domain verification pending", {
+              isDomainVerified: "false",
+              primaryDomain: primary.domainName,
+              verificationToken: verificationData.token,
+              verificationMethod: "DNS_TXT"
+            });
+          } catch {
+            markIncomplete("Domain not verified", {
+              isDomainVerified: "false",
+              primaryDomain: primary.domainName
+            });
+          }
+        } else {
+          markIncomplete("No primary domain found", {
+            isDomainVerified: "false"
+          });
+        }
+      } catch (error) {
+        log(LogLevel.Error, "Failed to check domains", { error });
+        markCheckFailed(
+          error instanceof Error ? error.message : "Failed to check domains"
+        );
+      }
+    }
+  )
+  .execute(
+    async ({ google, checkData, output, markFailed, markPending, log }) => {
+      try {
+        if (!checkData.primaryDomain) {
+          markFailed("No primary domain to verify");
+          return;
+        }
+
+        const VerifySchema = z.object({
+          id: z.string(),
+          site: z.object({ type: z.string(), identifier: z.string() })
         });
 
         try {
-          const verificationData = await fetchGoogle(
-            `${ApiEndpoint.Google.SiteVerification}/token`,
-            TokenSchema,
+          const verified = await google.post(
+            `${ApiEndpoint.Google.SiteVerification}/webResource`,
+            VerifySchema,
             {
-              method: "POST",
-              body: JSON.stringify({
-                site: { type: "INET_DOMAIN", identifier: primary.domainName },
-                verificationMethod: "DNS_TXT"
-              })
-            }
-          );
-
-          markIncomplete("Domain verification pending", {
-            isDomainVerified: "false",
-            primaryDomain: primary.domainName,
-            verificationToken: verificationData.token,
-            verificationMethod: "DNS_TXT"
-          });
-        } catch {
-          markIncomplete("Domain not verified", {
-            isDomainVerified: "false",
-            primaryDomain: primary.domainName
-          });
-        }
-      } else {
-        markIncomplete("No primary domain found", {
-          isDomainVerified: "false"
-        });
-      }
-    } catch (error) {
-      log(LogLevel.Error, "Failed to check domains", { error });
-      markCheckFailed(
-        error instanceof Error ? error.message : "Failed to check domains"
-      );
-    }
-  },
-
-  async execute({
-    fetchGoogle,
-    checkData,
-    markSucceeded,
-    markFailed,
-    markPending,
-    log
-  }) {
-    try {
-      if (!checkData.primaryDomain) {
-        markFailed("No primary domain to verify");
-        return;
-      }
-
-      const VerifySchema = z.object({
-        id: z.string(),
-        site: z.object({ type: z.string(), identifier: z.string() })
-      });
-
-      try {
-        const verified = await fetchGoogle(
-          `${ApiEndpoint.Google.SiteVerification}/webResource`,
-          VerifySchema,
-          {
-            method: "POST",
-            body: JSON.stringify({
               site: {
                 type: "INET_DOMAIN",
                 identifier: checkData.primaryDomain
               },
               verificationMethod: "DNS_TXT"
-            })
-          }
-        );
+            }
+          );
 
-        log(LogLevel.Info, "Domain verified successfully", { verified });
-        markSucceeded({
-          [Var.IsDomainVerified]: "true",
-          [Var.PrimaryDomain]: checkData.primaryDomain
-        });
-      } catch {
-        if (checkData.verificationToken) {
-          markPending(
-            `Add TXT record to DNS: ${checkData.verificationToken}\n`
-              + `Record name: @ or ${checkData.primaryDomain}\n`
-              + `This step will retry automatically once DNS propagates.`
-          );
-        } else {
-          markFailed(
-            "Unable to verify domain - no verification token available"
-          );
+          log(LogLevel.Info, "Domain verified successfully", { verified });
+          output({
+            isDomainVerified: "true",
+            primaryDomain: checkData.primaryDomain
+          });
+        } catch {
+          if (checkData.verificationToken) {
+            markPending(
+              `Add TXT record to DNS: ${checkData.verificationToken}\n`
+                + `Record name: @ or ${checkData.primaryDomain}\n`
+                + `This step will retry automatically once DNS propagates.`
+            );
+          } else {
+            markFailed(
+              "Unable to verify domain - no verification token available"
+            );
+          }
         }
+      } catch (error) {
+        log(LogLevel.Error, "Execute failed", { error });
+        markFailed(error instanceof Error ? error.message : "Execute failed");
       }
-    } catch (error) {
-      log(LogLevel.Error, "Execute failed", { error });
-      markFailed(error instanceof Error ? error.message : "Execute failed");
     }
-  },
-  undo: async ({ markReverted }) => {
+  )
+  .undo(async ({ markReverted }) => {
     markReverted();
-  }
-});
+  })
+  .build();


### PR DESCRIPTION
## Summary
- replace legacy step builder with new fluent builder
- refactor all workflow steps to use the builder API
- relax eslint rule requiring createStep

## Testing
- `npx pnpm lint`
- `npx pnpm check`
- `npx pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68545ac757fc8322961c228ed5f6c47e