### PR TITLE
Fix workflow step variable usage

### DIFF
--- a/lib/workflow/step-builder.ts
+++ b/lib/workflow/step-builder.ts
@@ -230,11 +230,15 @@ function createVarStore(vars: Partial<WorkflowVars>): VarStore {
   };
 }
 
-function wrapContext<C extends {
-  fetchGoogle: StepCheckContext<unknown>["fetchGoogle"];
-  fetchMicrosoft: StepCheckContext<unknown>["fetchMicrosoft"];
-  vars: Partial<WorkflowVars>;
-}>(ctx: C): Omit<C, "fetchGoogle" | "fetchMicrosoft" | "vars"> & {
+function wrapContext<
+  C extends {
+    fetchGoogle: StepCheckContext<unknown>["fetchGoogle"];
+    fetchMicrosoft: StepCheckContext<unknown>["fetchMicrosoft"];
+    vars: Partial<WorkflowVars>;
+  }
+>(
+  ctx: C
+): Omit<C, "fetchGoogle" | "fetchMicrosoft" | "vars"> & {
   vars: VarStore;
   google: HttpClient;
   microsoft: HttpClient;

--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -60,7 +60,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
             .optional()
         });
 
-        const profileId = vars.require("samlProfileId");
+        const profileId = vars.require(Var.SamlProfileId);
 
         const { inboundSsoAssignments = [] } = await google.get(
           ApiEndpoint.Google.SsoAssignments,
@@ -108,7 +108,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
      * { "error": { "message": "Assignment already exists" } }
      */
     try {
-      const profileId = vars.require("samlProfileId");
+      const profileId = vars.require(Var.SamlProfileId);
 
       const OpSchema = z.object({
         name: z.string(),
@@ -154,7 +154,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
   })
   .undo(async ({ vars, google, markReverted, markFailed, log }) => {
     try {
-      const profileId = vars.get("samlProfileId");
+      const profileId = vars.get(Var.SamlProfileId);
       if (!profileId) {
         markFailed("Missing samlProfileId");
         return;

--- a/lib/workflow/steps/complete-google-sso-setup.ts
+++ b/lib/workflow/steps/complete-google-sso-setup.ts
@@ -22,7 +22,7 @@ export default defineStep(StepId.CompleteGoogleSsoSetup)
       log
     }) => {
       try {
-        const profileId = vars.require("samlProfileId");
+        const profileId = vars.require(Var.SamlProfileId);
 
         if (!profileId) {
           markIncomplete("SAML profile ID not provided", {});
@@ -70,8 +70,8 @@ export default defineStep(StepId.CompleteGoogleSsoSetup)
   )
   .execute(async ({ vars, google, microsoft, output, markFailed, log }) => {
     try {
-      const profileId = vars.require("samlProfileId");
-      const ssoSpId = vars.require("ssoServicePrincipalId");
+      const profileId = vars.require(Var.SamlProfileId);
+      const ssoSpId = vars.require(Var.SsoServicePrincipalId);
 
       log(LogLevel.Info, "Fetching SAML metadata from Microsoft");
 

--- a/lib/workflow/steps/configure-google-saml-profile.ts
+++ b/lib/workflow/steps/configure-google-saml-profile.ts
@@ -116,7 +116,7 @@ export default defineStep(StepId.ConfigureGoogleSamlProfile)
         "/customers/my_customer/inboundSamlSsoProfiles"
       )}`;
       const op = await google.post(createUrl, opSchema, {
-        displayName: vars.require("samlProfileDisplayName"),
+        displayName: vars.require(Var.SamlProfileDisplayName),
         idpConfig: { entityId: "", singleSignOnServiceUri: "" }
       });
 
@@ -150,7 +150,7 @@ export default defineStep(StepId.ConfigureGoogleSamlProfile)
   })
   .undo(async ({ vars, google, markReverted, markFailed, log }) => {
     try {
-      const id = vars.get("samlProfileId");
+      const id = vars.get(Var.SamlProfileId);
       if (!id) {
         markFailed("Missing samlProfileId");
         return;

--- a/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
+++ b/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
@@ -35,7 +35,7 @@ export default defineStep(StepId.ConfigureMicrosoftSyncAndSso)
       log
     }) => {
       try {
-        const spId = vars.require("provisioningServicePrincipalId");
+        const spId = vars.require(Var.ProvisioningServicePrincipalId);
         if (!spId) {
           markIncomplete("Missing provisioning service principal ID", {});
           return;
@@ -78,8 +78,8 @@ export default defineStep(StepId.ConfigureMicrosoftSyncAndSso)
      * POST https://graph.microsoft.com/v1.0/servicePrincipals/{provisioningServicePrincipalId}/synchronization/jobs/{jobId}/start
      */
     try {
-      const spId = vars.require("provisioningServicePrincipalId");
-      const password = vars.require("generatedPassword");
+      const spId = vars.require(Var.ProvisioningServicePrincipalId);
+      const password = vars.require(Var.GeneratedPassword);
 
       const baseAddress = ApiEndpoint.Google.Users.replace("/users", "");
 
@@ -123,7 +123,7 @@ export default defineStep(StepId.ConfigureMicrosoftSyncAndSso)
   })
   .undo(async ({ vars, microsoft, markReverted, markFailed, log }) => {
     try {
-      const spId = vars.get("provisioningServicePrincipalId");
+      const spId = vars.get(Var.ProvisioningServicePrincipalId);
       if (!spId) {
         markFailed("Missing service principal id");
         return;

--- a/lib/workflow/steps/create-admin-role-and-assign-user.ts
+++ b/lib/workflow/steps/create-admin-role-and-assign-user.ts
@@ -85,7 +85,7 @@ export default defineStep(StepId.CreateAdminRoleAndAssignUser)
           RolesSchema,
           { flatten: true }
         );
-        const roleName = vars.require("adminRoleName");
+        const roleName = vars.require(Var.AdminRoleName);
         const role = items.find((r) => r.roleName === roleName);
         if (role) {
           const privNames = role.rolePrivileges.map((p) => p.privilegeName);
@@ -98,7 +98,7 @@ export default defineStep(StepId.CreateAdminRoleAndAssignUser)
             });
             return;
           }
-          const userId = vars.require("provisioningUserId");
+          const userId = vars.require(Var.ProvisioningUserId);
 
           const AssignmentsSchema = z.object({
             items: z
@@ -216,7 +216,7 @@ export default defineStep(StepId.CreateAdminRoleAndAssignUser)
       let roleId = checkData.adminRoleId;
       try {
         const res = await google.post(ApiEndpoint.Google.Roles, CreateSchema, {
-          roleName: vars.require("adminRoleName"),
+          roleName: vars.require(Var.AdminRoleName),
           roleDescription: "Custom role for Microsoft provisioning",
           rolePrivileges: [
             { serviceId, privilegeName: "ORGANIZATION_UNITS_RETRIEVE" },
@@ -251,7 +251,7 @@ export default defineStep(StepId.CreateAdminRoleAndAssignUser)
               RolesSchema,
               { flatten: true }
             );
-            const roleName = vars.require("adminRoleName");
+            const roleName = vars.require(Var.AdminRoleName);
             roleId = rolesList.find((r) => r.roleName === roleName)?.roleId;
           }
         } else {
@@ -261,7 +261,7 @@ export default defineStep(StepId.CreateAdminRoleAndAssignUser)
 
       if (!roleId) throw new Error("Role ID unavailable after create");
 
-      const userId = vars.require("provisioningUserId");
+      const userId = vars.require(Var.ProvisioningUserId);
       const AssignSchema = z.object({ kind: z.string().optional() });
       try {
         /**
@@ -305,8 +305,8 @@ export default defineStep(StepId.CreateAdminRoleAndAssignUser)
   })
   .undo(async ({ vars, google, markReverted, markFailed, log }) => {
     try {
-      const roleId = vars.get("adminRoleId");
-      const userId = vars.get("provisioningUserId");
+      const roleId = vars.get(Var.AdminRoleId);
+      const userId = vars.get(Var.ProvisioningUserId);
       if (!roleId || !userId) {
         markFailed("Missing role or user id");
         return;

--- a/lib/workflow/steps/create-automation-ou.ts
+++ b/lib/workflow/steps/create-automation-ou.ts
@@ -47,7 +47,7 @@ export default defineStep(StepId.CreateAutomationOU)
       log
     }) => {
       try {
-        const ouName = vars.require("automationOuName");
+        const ouName = vars.require(Var.AutomationOuName);
 
         const OrgUnitSchema = z.object({ orgUnitPath: z.string() });
         await google.get(
@@ -95,7 +95,7 @@ export default defineStep(StepId.CreateAutomationOU)
       });
 
       await google.post(ApiEndpoint.Google.OrgUnits, CreateSchema, {
-        name: vars.require("automationOuName"),
+        name: vars.require(Var.AutomationOuName),
         parentOrgUnitPath: "/"
       });
 
@@ -112,7 +112,7 @@ export default defineStep(StepId.CreateAutomationOU)
   })
   .undo(async ({ vars, google, markReverted, markFailed, log }) => {
     try {
-      const path = vars.require("automationOuPath");
+      const path = vars.require(Var.AutomationOuPath);
       if (!path) {
         markFailed("Missing Automation OU name");
         return;

--- a/lib/workflow/steps/create-microsoft-apps.ts
+++ b/lib/workflow/steps/create-microsoft-apps.ts
@@ -149,13 +149,13 @@ export default defineStep(StepId.CreateMicrosoftApps)
       const res1 = await microsoft.post(
         ApiEndpoint.Microsoft.Templates(TemplateId.GoogleWorkspaceConnector),
         CreateSchema,
-        { displayName: vars.require("provisioningAppDisplayName") }
+        { displayName: vars.require(Var.ProvisioningAppDisplayName) }
       );
 
       const res2 = await microsoft.post(
         ApiEndpoint.Microsoft.Templates(TemplateId.GoogleWorkspaceSaml),
         CreateSchema,
-        { displayName: vars.require("ssoAppDisplayName") }
+        { displayName: vars.require(Var.SsoAppDisplayName) }
       );
 
       output({
@@ -170,9 +170,9 @@ export default defineStep(StepId.CreateMicrosoftApps)
   })
   .undo(async ({ vars, microsoft, markReverted, markFailed, log }) => {
     try {
-      const provSpId = vars.get("provisioningServicePrincipalId");
-      const ssoSpId = vars.get("ssoServicePrincipalId");
-      const appId = vars.get("ssoAppId");
+      const provSpId = vars.get(Var.ProvisioningServicePrincipalId);
+      const ssoSpId = vars.get(Var.SsoServicePrincipalId);
+      const appId = vars.get(Var.SsoAppId);
 
       if (provSpId) {
         await microsoft.delete(

--- a/lib/workflow/steps/create-service-user.ts
+++ b/lib/workflow/steps/create-service-user.ts
@@ -48,8 +48,8 @@ export default defineStep(StepId.CreateServiceUser)
       log
     }) => {
       try {
-        vars.require("primaryDomain");
-        vars.require("provisioningUserPrefix");
+        vars.require(Var.PrimaryDomain);
+        vars.require(Var.ProvisioningUserPrefix);
 
         const UserSchema = z
           .object({
@@ -114,7 +114,7 @@ export default defineStep(StepId.CreateServiceUser)
        * { "error": { "message": "Entity already exists." } }
        */
       try {
-        vars.require("primaryDomain");
+        vars.require(Var.PrimaryDomain);
 
         const BYTES = 4;
         const password = `Temp${crypto.randomBytes(BYTES).toString("hex")}!`;
@@ -125,8 +125,8 @@ export default defineStep(StepId.CreateServiceUser)
 
         let user;
         try {
-          vars.require("provisioningUserPrefix");
-          const ouPath = vars.require("automationOuPath");
+          vars.require(Var.ProvisioningUserPrefix);
+          const ouPath = vars.require(Var.AutomationOuPath);
           user = await google.post(ApiEndpoint.Google.Users, CreateSchema, {
             primaryEmail: vars.build(
               "{provisioningUserPrefix}@{primaryDomain}"
@@ -168,7 +168,7 @@ export default defineStep(StepId.CreateServiceUser)
   )
   .undo(async ({ vars, google, markReverted, markFailed, log }) => {
     try {
-      const id = vars.get("provisioningUserId");
+      const id = vars.get(Var.ProvisioningUserId);
       if (!id) {
         markFailed("Missing provisioning user id");
         return;

--- a/lib/workflow/steps/setup-microsoft-claims-policy.ts
+++ b/lib/workflow/steps/setup-microsoft-claims-policy.ts
@@ -39,7 +39,7 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
       log
     }) => {
       try {
-        const spId = vars.require("ssoServicePrincipalId");
+        const spId = vars.require(Var.SsoServicePrincipalId);
         if (!spId) {
           markIncomplete("Missing SSO service principal ID", {});
           return;
@@ -86,7 +86,7 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
      * 204
      */
     try {
-      const spId = vars.require("ssoServicePrincipalId");
+      const spId = vars.require(Var.SsoServicePrincipalId);
 
       const PolicySchema = z.object({ id: z.string() });
 
@@ -99,7 +99,7 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
             definition: [
               '{"ClaimsMappingPolicy":{"Version":1,"IncludeBasicClaimSet":true,"ClaimsSchema":[]}}'
             ],
-            displayName: vars.require("claimsPolicyDisplayName"),
+            displayName: vars.require(Var.ClaimsPolicyDisplayName),
             isOrganizationDefault: false
           }
         );
@@ -149,8 +149,8 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
   })
   .undo(async ({ vars, microsoft, markReverted, markFailed, log }) => {
     try {
-      const spId = vars.get("ssoServicePrincipalId");
-      const policyId = vars.get("claimsPolicyId");
+      const spId = vars.get(Var.SsoServicePrincipalId);
+      const policyId = vars.get(Var.ClaimsPolicyId);
       if (!policyId) {
         markFailed("Missing claims policy id");
         return;

--- a/types.ts
+++ b/types.ts
@@ -110,13 +110,6 @@ export interface StepUndoContext {
   markFailed(error: string): void;
 }
 
-export interface StepLogEntry {
-  timestamp: number;
-  message: string;
-  data?: unknown;
-  level?: LogLevel;
-}
-
 export interface StepUIState {
   status:
     | "idle"


### PR DESCRIPTION
## Summary
- remove duplicate `StepLogEntry` interface definition
- use `Var` enum constants instead of string literals across steps
- apply formatting from lint

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68548163fc5c8322b48137982407565c