### PR TITLE
Fix missing StepLogEntry type

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,13 @@ export { StepId } from "./lib/workflow/step-ids";
 export { Var } from "./lib/workflow/variables";
 export type { StepIdValue, VarName, WorkflowVars };
 
+export interface StepLogEntry {
+  timestamp: number;
+  message: string;
+  data?: unknown;
+  level?: LogLevel;
+}
+
 export enum LogLevel {
   Info = "info",
   Warn = "warn",


### PR DESCRIPTION
## Summary
- restore `StepLogEntry` interface in `types.ts`

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68548671760083229715e649eb7b1b06