### PR TITLE
Deduplicate VarStore and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,6 @@ Use only values from these enums — no string literals allowed:
 
 - `Var` (e.g. `Var.GoogleAccessToken`)
 - `StepId` (e.g. `StepId.CreateServiceUser`)
-- `StepOutcome` (e.g. `StepOutcome.Succeeded`)
 - `LogLevel` (e.g. `LogLevel.Info`)
 
 ## ✅ Logging
@@ -66,7 +65,7 @@ interface StepCheckResult {
 }
 
 interface StepExecuteResult<K extends Var> {
-  status: StepOutcome;
+  status: StepUIState["status"];
   output?: Partial<Pick<WorkflowVars, K>>;
   notes?: string;
   error?: string;

--- a/eslint.rules.mjs
+++ b/eslint.rules.mjs
@@ -997,7 +997,6 @@ export const importTypesFromTypes = createRule({
     const coreTypes = new Set([
       "Var",
       "StepId",
-      "StepOutcome",
       "LogLevel",
       "WorkflowVars",
       "StepCheckContext",

--- a/lib/workflow/steps/complete-google-sso-setup.ts
+++ b/lib/workflow/steps/complete-google-sso-setup.ts
@@ -24,11 +24,6 @@ export default defineStep(StepId.CompleteGoogleSsoSetup)
       try {
         const profileId = vars.require(Var.SamlProfileId);
 
-        if (!profileId) {
-          markIncomplete("SAML profile ID not provided", {});
-          return;
-        }
-
         const ProfileSchema = z.object({
           name: z.string(),
           idpConfig: z
@@ -197,10 +192,6 @@ export default defineStep(StepId.CompleteGoogleSsoSetup)
 
       const updateMask =
         "idpConfig.entityId,idpConfig.singleSignOnServiceUri,idpConfig.signOutUri,idpConfig.changePasswordUri";
-
-      if (!profileId) {
-        throw new Error("SAML profile ID not provided");
-      }
 
       const patchUrl = `${ApiEndpoint.Google.SamlProfile(profileId)}?updateMask=${encodeURIComponent(updateMask)}`;
 

--- a/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
+++ b/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
@@ -36,10 +36,6 @@ export default defineStep(StepId.ConfigureMicrosoftSyncAndSso)
     }) => {
       try {
         const spId = vars.require(Var.ProvisioningServicePrincipalId);
-        if (!spId) {
-          markIncomplete("Missing provisioning service principal ID", {});
-          return;
-        }
 
         const JobsSchema = z.object({
           value: z.array(z.object({ status: z.object({ code: z.string() }) }))
@@ -88,10 +84,6 @@ export default defineStep(StepId.ConfigureMicrosoftSyncAndSso)
         templateId: z.string(),
         status: z.object({ code: z.string() }).optional()
       });
-      if (!spId) {
-        markFailed("Missing provisioning service principal ID");
-        return;
-      }
 
       const job = await microsoft.post(
         ApiEndpoint.Microsoft.SyncJobs(spId),

--- a/lib/workflow/steps/setup-microsoft-claims-policy.ts
+++ b/lib/workflow/steps/setup-microsoft-claims-policy.ts
@@ -40,10 +40,6 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
     }) => {
       try {
         const spId = vars.require(Var.SsoServicePrincipalId);
-        if (!spId) {
-          markIncomplete("Missing SSO service principal ID", {});
-          return;
-        }
 
         const PoliciesSchema = z.object({
           value: z.array(z.object({ id: z.string() }))
@@ -121,10 +117,6 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
       }
 
       if (!policyId) throw new Error("Policy ID unavailable");
-      if (!spId) {
-        markFailed("Missing SSO service principal ID");
-        return;
-      }
 
       try {
         await microsoft.post(

--- a/lib/workflow/var-store.ts
+++ b/lib/workflow/var-store.ts
@@ -1,0 +1,27 @@
+import type { VarName, WorkflowVars } from "./variables";
+
+export interface BasicVarStore {
+  get<K extends VarName>(key: K): WorkflowVars[K] | undefined;
+  require<K extends VarName>(key: K): NonNullable<WorkflowVars[K]>;
+  build(template: string): string;
+}
+
+export function createVarStore(vars: Partial<WorkflowVars>): BasicVarStore {
+  return {
+    get: <K extends VarName>(key: K) => vars[key],
+    require: <K extends VarName>(key: K) => {
+      const value = vars[key];
+      if (value === undefined)
+        throw new Error(`Required variable ${key} is missing`);
+      return value as NonNullable<WorkflowVars[K]>;
+    },
+    build: (template: string) => {
+      return template.replace(/\{(\w+)\}/g, (_, key) => {
+        const value = vars[key as VarName];
+        if (value === undefined)
+          throw new Error(`Template variable ${key} is missing`);
+        return String(value);
+      });
+    }
+  };
+}

--- a/types.ts
+++ b/types.ts
@@ -92,3 +92,10 @@ export interface StepUIState {
   notes?: string;
   logs?: StepLogEntry[];
 }
+
+export interface StepLogEntry {
+  timestamp: number;
+  message: string;
+  level: LogLevel;
+  data?: unknown;
+}


### PR DESCRIPTION
## Summary
- share VarStore logic between server and client via `createVarStore`
- reference the shared store in step builder and workflow context
- clean up redundant require checks in step implementations
- drop legacy `StepOutcome` references
- define missing `StepLogEntry` type

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68548a19c7d4832289e334bf2d9c2249