### PR TITLE
Add OU info dialog

### DIFF
--- a/API_STATUS.md
+++ b/API_STATUS.md
@@ -105,3 +105,12 @@ _check_ success:
 ### testSsoConfiguration
 
 - Manual verification of SSO login
+
+### info server actions
+
+- listOrgUnits: verified 200 response listing organizational units
+- listSamlProfiles: verified 200 response listing SAML profiles
+- listSsoAssignments: verified 200 response listing assignments
+- listProvisioningJobs: verified 200 response (0 jobs returned)
+- listClaimsPolicies: verified 200 response listing claims policies
+- listEnterpriseApps: verified 200 response listing apps

--- a/components/apps-info-button.tsx
+++ b/components/apps-info-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { InfoButton } from "@/components/info-button";
+import { listEnterpriseApps } from "@/lib/info";
+
+export function AppsInfoButton() {
+  return (
+    <InfoButton
+      title="Existing Enterprise Apps"
+      fetchItems={listEnterpriseApps}
+    />
+  );
+}

--- a/components/claims-info-button.tsx
+++ b/components/claims-info-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { InfoButton } from "@/components/info-button";
+import { listClaimsPolicies } from "@/lib/info";
+
+export function ClaimsInfoButton() {
+  return (
+    <InfoButton
+      title="Existing Claims Policies"
+      fetchItems={listClaimsPolicies}
+    />
+  );
+}

--- a/components/info-button.tsx
+++ b/components/info-button.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from "@/components/ui/dialog";
+import { Info } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export interface InfoItem {
+  id: string;
+  label: string;
+  href?: string;
+}
+
+interface InfoButtonProps {
+  title: string;
+  fetchItems: () => Promise<InfoItem[]>;
+}
+
+export function InfoButton({ title, fetchItems }: InfoButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [items, setItems] = useState<InfoItem[]>([]);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!open) return;
+    const load = async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        const res = await fetchItems();
+        setItems(res);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [open, fetchItems]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          className="border-slate-300 text-slate-700">
+          <Info className="h-3.5 w-3.5 mr-1.5" /> Info
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {loading && <p className="text-sm text-slate-600">Loading...</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {!loading && !error && (
+          <ul className="space-y-2">
+            {items.map((item) => (
+              <li key={item.id} className="text-sm">
+                {item.href ?
+                  <a
+                    href={item.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 underline">
+                    {item.label}
+                  </a>
+                : <span>{item.label}</span>}
+              </li>
+            ))}
+            {items.length === 0 && (
+              <li className="text-slate-600">No entries found.</li>
+            )}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ou-info-button.tsx
+++ b/components/ou-info-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { InfoButton } from "@/components/info-button";
+import { listOrgUnits } from "@/lib/info";
+
+export function OuInfoButton() {
+  return (
+    <InfoButton
+      title="Existing Organizational Units"
+      fetchItems={listOrgUnits}
+    />
+  );
+}

--- a/components/provisioning-info-button.tsx
+++ b/components/provisioning-info-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { InfoButton } from "@/components/info-button";
+import { listProvisioningJobs } from "@/lib/info";
+
+export function ProvisioningInfoButton() {
+  return (
+    <InfoButton
+      title="Existing Provisioning Jobs"
+      fetchItems={listProvisioningJobs}
+    />
+  );
+}

--- a/components/saml-info-button.tsx
+++ b/components/saml-info-button.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { InfoButton } from "@/components/info-button";
+import { listSamlProfiles } from "@/lib/info";
+
+export function SamlInfoButton() {
+  return (
+    <InfoButton title="Existing SAML Profiles" fetchItems={listSamlProfiles} />
+  );
+}

--- a/components/sso-info-button.tsx
+++ b/components/sso-info-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { InfoButton } from "@/components/info-button";
+import { listSsoAssignments } from "@/lib/info";
+
+export function SsoInfoButton() {
+  return (
+    <InfoButton
+      title="Existing SSO Assignments"
+      fetchItems={listSsoAssignments}
+    />
+  );
+}

--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import { AppsInfoButton } from "@/components/apps-info-button";
+import { ClaimsInfoButton } from "@/components/claims-info-button";
+import { OuInfoButton } from "@/components/ou-info-button";
+import { ProvisioningInfoButton } from "@/components/provisioning-info-button";
+import { SamlInfoButton } from "@/components/saml-info-button";
+import { SsoInfoButton } from "@/components/sso-info-button";
 import { StepApiCalls } from "@/components/step-api-calls";
 import { StepLogs } from "@/components/step-logs";
 import { StepVariables } from "@/components/step-variables";
@@ -13,6 +19,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { WORKFLOW_VARIABLES } from "@/lib/workflow/variables";
+import { StepId } from "@/types";
 
 import {
   StepDefinition,
@@ -306,6 +313,22 @@ export function StepCard({
                   <Zap className="h-3.5 w-3.5 mr-1.5" />
                   Force
                 </Button>
+                {definition.id === StepId.CreateAutomationOU && (
+                  <OuInfoButton />
+                )}
+                {definition.id === StepId.ConfigureGoogleSamlProfile && (
+                  <SamlInfoButton />
+                )}
+                {definition.id === StepId.AssignUsersToSso && <SsoInfoButton />}
+                {definition.id === StepId.CreateMicrosoftApps && (
+                  <AppsInfoButton />
+                )}
+                {definition.id === StepId.ConfigureMicrosoftSyncAndSso && (
+                  <ProvisioningInfoButton />
+                )}
+                {definition.id === StepId.SetupMicrosoftClaimsPolicy && (
+                  <ClaimsInfoButton />
+                )}
               </div>
               {state?.logs && state.logs.length > 0 && (
                 <Badge

--- a/lib/info.ts
+++ b/lib/info.ts
@@ -1,0 +1,171 @@
+"use server";
+import "server-only";
+
+import { ApiEndpoint, PROVIDERS, TemplateId } from "@/constants";
+import { refreshTokenIfNeeded } from "@/lib/auth";
+import { z } from "zod";
+
+export interface InfoItem {
+  id: string;
+  label: string;
+  href?: string;
+}
+
+export async function listOrgUnits(): Promise<InfoItem[]> {
+  const token = await refreshTokenIfNeeded(PROVIDERS.GOOGLE);
+  if (!token) return [];
+
+  const Schema = z.object({
+    organizationUnits: z
+      .array(
+        z.object({
+          orgUnitId: z.string(),
+          name: z.string(),
+          orgUnitPath: z.string()
+        })
+      )
+      .optional()
+  });
+
+  const res = await fetch(`${ApiEndpoint.Google.OrgUnits}?type=all`, {
+    headers: { Authorization: `Bearer ${token.accessToken}` }
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = Schema.parse(await res.json());
+  return (
+    data.organizationUnits?.map((ou) => ({
+      id: ou.orgUnitId,
+      label: ou.orgUnitPath,
+      href: `https://admin.google.com/ac/orgunits?ouid=${encodeURIComponent(
+        ou.orgUnitId.replace(/^id:/, "")
+      )}`
+    })) ?? []
+  );
+}
+
+export async function listSamlProfiles(): Promise<InfoItem[]> {
+  const token = await refreshTokenIfNeeded(PROVIDERS.GOOGLE);
+  if (!token) return [];
+
+  const Schema = z.object({
+    inboundSamlSsoProfiles: z
+      .array(z.object({ name: z.string(), displayName: z.string().optional() }))
+      .optional()
+  });
+
+  const res = await fetch(ApiEndpoint.Google.SsoProfiles, {
+    headers: { Authorization: `Bearer ${token.accessToken}` }
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = Schema.parse(await res.json());
+  return (
+    data.inboundSamlSsoProfiles?.map((p) => ({
+      id: p.name,
+      label: p.displayName ?? p.name,
+      href: undefined
+    })) ?? []
+  );
+}
+
+export async function listSsoAssignments(): Promise<InfoItem[]> {
+  const token = await refreshTokenIfNeeded(PROVIDERS.GOOGLE);
+  if (!token) return [];
+
+  const Schema = z.object({
+    inboundSsoAssignments: z
+      .array(
+        z.object({
+          name: z.string(),
+          targetGroup: z.string().optional(),
+          targetOrgUnit: z.string().optional(),
+          ssoMode: z.string().optional()
+        })
+      )
+      .optional()
+  });
+
+  const res = await fetch(ApiEndpoint.Google.SsoAssignments, {
+    headers: { Authorization: `Bearer ${token.accessToken}` }
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = Schema.parse(await res.json());
+  return (
+    data.inboundSsoAssignments?.map((a) => ({
+      id: a.name,
+      label: a.targetGroup || a.targetOrgUnit || a.name,
+      href: undefined
+    })) ?? []
+  );
+}
+
+export async function listProvisioningJobs(): Promise<InfoItem[]> {
+  const token = await refreshTokenIfNeeded(PROVIDERS.MICROSOFT);
+  if (!token) return [];
+
+  const SpSchema = z.object({ value: z.array(z.object({ id: z.string() })) });
+  const spFilter = encodeURIComponent(
+    "displayName eq 'Google Workspace Provisioning'"
+  );
+  const spRes = await fetch(
+    `${ApiEndpoint.Microsoft.ServicePrincipals}?$filter=${spFilter}`,
+    { headers: { Authorization: `Bearer ${token.accessToken}` } }
+  );
+  if (!spRes.ok) throw new Error(`HTTP ${spRes.status}`);
+  const spData = SpSchema.parse(await spRes.json());
+  const spId = spData.value[0]?.id;
+  if (!spId) return [];
+
+  const JobsSchema = z.object({
+    value: z.array(
+      z.object({
+        id: z.string(),
+        status: z.object({ code: z.string().optional() }).optional()
+      })
+    )
+  });
+
+  const res = await fetch(ApiEndpoint.Microsoft.SyncJobs(spId), {
+    headers: { Authorization: `Bearer ${token.accessToken}` }
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = JobsSchema.parse(await res.json());
+  return data.value.map((j) => ({ id: j.id, label: j.status?.code ?? j.id }));
+}
+
+export async function listClaimsPolicies(): Promise<InfoItem[]> {
+  const token = await refreshTokenIfNeeded(PROVIDERS.MICROSOFT);
+  if (!token) return [];
+
+  const Schema = z.object({
+    value: z.array(
+      z.object({ id: z.string(), displayName: z.string().optional() })
+    )
+  });
+
+  const res = await fetch(ApiEndpoint.Microsoft.ClaimsPolicies, {
+    headers: { Authorization: `Bearer ${token.accessToken}` }
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = Schema.parse(await res.json());
+  return data.value.map((p) => ({ id: p.id, label: p.displayName ?? p.id }));
+}
+
+export async function listEnterpriseApps(): Promise<InfoItem[]> {
+  const token = await refreshTokenIfNeeded(PROVIDERS.MICROSOFT);
+  if (!token) return [];
+
+  const Schema = z.object({
+    value: z.array(z.object({ id: z.string(), displayName: z.string() }))
+  });
+
+  const filter = encodeURIComponent(
+    `applicationTemplateId eq '${TemplateId.GoogleWorkspaceConnector}' or applicationTemplateId eq '${TemplateId.GoogleWorkspaceSaml}'`
+  );
+  const res = await fetch(
+    `${ApiEndpoint.Microsoft.Applications}?$filter=${filter}`,
+    { headers: { Authorization: `Bearer ${token.accessToken}` } }
+  );
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = Schema.parse(await res.json());
+  return data.value.map((a) => ({ id: a.id, label: a.displayName }));
+}

--- a/test/info/fixtures/google-org-units.json
+++ b/test/info/fixtures/google-org-units.json
@@ -1,0 +1,9 @@
+{
+  "organizationUnits": [
+    {
+      "orgUnitId": "id:123",
+      "name": "Automation",
+      "orgUnitPath": "/Automation"
+    }
+  ]
+}

--- a/test/info/fixtures/google-saml-profiles.json
+++ b/test/info/fixtures/google-saml-profiles.json
@@ -1,0 +1,5 @@
+{
+  "inboundSamlSsoProfiles": [
+    { "name": "samlProfiles/abc123", "displayName": "Workspace SAML" }
+  ]
+}

--- a/test/info/fixtures/google-sso-assignments.json
+++ b/test/info/fixtures/google-sso-assignments.json
@@ -1,0 +1,5 @@
+{
+  "inboundSsoAssignments": [
+    { "name": "assignments/allUsers", "targetGroup": "groups/allUsers" }
+  ]
+}

--- a/test/info/fixtures/ms-applications.json
+++ b/test/info/fixtures/ms-applications.json
@@ -1,0 +1,9 @@
+{
+  "value": [
+    {
+      "id": "app1",
+      "appId": "abcd1234",
+      "displayName": "Google Workspace Provisioning"
+    }
+  ]
+}

--- a/test/info/fixtures/ms-claims-policies.json
+++ b/test/info/fixtures/ms-claims-policies.json
@@ -1,0 +1,1 @@
+{ "value": [{ "id": "policy123", "displayName": "Google Workspace Claims" }] }

--- a/test/info/fixtures/ms-sync-jobs.json
+++ b/test/info/fixtures/ms-sync-jobs.json
@@ -1,0 +1,1 @@
+{ "value": [{ "id": "Initial", "status": { "code": "Active" } }] }

--- a/test/info/info.test.ts
+++ b/test/info/info.test.ts
@@ -1,0 +1,112 @@
+import { refreshTokenIfNeeded } from "@/lib/auth";
+import {
+  listClaimsPolicies,
+  listEnterpriseApps,
+  listOrgUnits,
+  listProvisioningJobs,
+  listSamlProfiles,
+  listSsoAssignments
+} from "@/lib/info";
+import fs from "fs";
+import path from "path";
+
+jest.mock("@/lib/auth", () => ({ refreshTokenIfNeeded: jest.fn() }));
+
+const token = { accessToken: "tok", refreshToken: "", expiresAt: 0, scope: [] };
+
+function load(name: string) {
+  const p = path.join(__dirname, "fixtures", name);
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+describe("info server actions", () => {
+  beforeEach(() => {
+    (refreshTokenIfNeeded as jest.Mock).mockResolvedValue(token);
+  });
+
+  test("listOrgUnits", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => load("google-org-units.json")
+      });
+    const items = await listOrgUnits();
+    expect(items).toEqual([
+      {
+        id: "id:123",
+        label: "/Automation",
+        href: "https://admin.google.com/ac/orgunits?ouid=123"
+      }
+    ]);
+  });
+
+  test("listSamlProfiles", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => load("google-saml-profiles.json")
+      });
+    const items = await listSamlProfiles();
+    expect(items).toEqual([
+      { id: "samlProfiles/abc123", label: "Workspace SAML", href: undefined }
+    ]);
+  });
+
+  test("listSsoAssignments", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => load("google-sso-assignments.json")
+      });
+    const items = await listSsoAssignments();
+    expect(items).toEqual([
+      { id: "assignments/allUsers", label: "groups/allUsers", href: undefined }
+    ]);
+  });
+
+  test("listProvisioningJobs", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [{ id: "sp1" }] })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => load("ms-sync-jobs.json")
+      });
+    const items = await listProvisioningJobs();
+    expect(items).toEqual([
+      { id: "Initial", label: "Active", href: undefined }
+    ]);
+  });
+
+  test("listClaimsPolicies", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => load("ms-claims-policies.json")
+      });
+    const items = await listClaimsPolicies();
+    expect(items).toEqual([
+      { id: "policy123", label: "Google Workspace Claims", href: undefined }
+    ]);
+  });
+
+  test("listEnterpriseApps", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => load("ms-applications.json")
+      });
+    const items = await listEnterpriseApps();
+    expect(items).toEqual([
+      { id: "app1", label: "Google Workspace Provisioning", href: undefined }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- create server actions to list org units, SAML profiles and SSO assignments
- make reusable `InfoButton` component
- show info buttons on the relevant workflow steps
- remove the old `/api/info/orgunits` route
- add more info utilities for provisioning jobs, claims policies and enterprise apps
- include tests with sample responses
- document manual validation of info server actions
- note successful Microsoft API responses after token fix

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `npx jest test/info/info.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_685490cf6c6883228830e22ac272d69f