### PR TITLE
Fix stray verificationMethod variable

### DIFF
--- a/lib/workflow/steps/verify-primary-domain.ts
+++ b/lib/workflow/steps/verify-primary-domain.ts
@@ -100,8 +100,7 @@ export default defineStep(StepId.VerifyPrimaryDomain)
             markIncomplete("Domain verification pending", {
               isDomainVerified: "false",
               primaryDomain: primary.domainName,
-              verificationToken: verificationData.token,
-              verificationMethod: "DNS_TXT"
+              verificationToken: verificationData.token
             });
           } catch {
             markIncomplete("Domain not verified", {


### PR DESCRIPTION
## Summary
- clean up VerifyPrimaryDomain step

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6854b234f0d48322891016d47648d114