### PR TITLE
Hide purge controls when disabled

### DIFF
--- a/components/apps-info-button.tsx
+++ b/components/apps-info-button.tsx
@@ -2,6 +2,7 @@
 
 import { InfoButton } from "@/components/info-button";
 import { PROTECTED_RESOURCES } from "@/constants";
+import { env } from "@/env";
 import { listEnterpriseApps } from "@/lib/info";
 import { deleteEnterpriseApps } from "@/lib/workflow/info-actions";
 
@@ -16,7 +17,7 @@ export function AppsInfoButton() {
           deletable: !PROTECTED_RESOURCES.microsoftAppIds.has(item.id)
         }));
       }}
-      deleteItems={deleteEnterpriseApps}
+      deleteItems={env.ALLOW_INFO_PURGE ? deleteEnterpriseApps : undefined}
     />
   );
 }

--- a/components/claims-info-button.tsx
+++ b/components/claims-info-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InfoButton } from "@/components/info-button";
+import { env } from "@/env";
 import { listClaimsPolicies } from "@/lib/info";
 import { deleteClaimsPolicies } from "@/lib/workflow/info-actions";
 
@@ -9,7 +10,7 @@ export function ClaimsInfoButton() {
     <InfoButton
       title="Existing Claims Policies"
       fetchItems={listClaimsPolicies}
-      deleteItems={deleteClaimsPolicies}
+      deleteItems={env.ALLOW_INFO_PURGE ? deleteClaimsPolicies : undefined}
     />
   );
 }

--- a/components/ou-info-button.tsx
+++ b/components/ou-info-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InfoButton } from "@/components/info-button";
+import { env } from "@/env";
 import { listOrgUnits } from "@/lib/info";
 import { deleteOrgUnits } from "@/lib/workflow/info-actions";
 
@@ -9,7 +10,7 @@ export function OuInfoButton() {
     <InfoButton
       title="Existing Organizational Units"
       fetchItems={listOrgUnits}
-      deleteItems={deleteOrgUnits}
+      deleteItems={env.ALLOW_INFO_PURGE ? deleteOrgUnits : undefined}
     />
   );
 }

--- a/components/provisioning-info-button.tsx
+++ b/components/provisioning-info-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InfoButton } from "@/components/info-button";
+import { env } from "@/env";
 import { listProvisioningJobs } from "@/lib/info";
 import { deleteProvisioningJobs } from "@/lib/workflow/info-actions";
 
@@ -9,7 +10,7 @@ export function ProvisioningInfoButton() {
     <InfoButton
       title="Existing Provisioning Jobs"
       fetchItems={listProvisioningJobs}
-      deleteItems={deleteProvisioningJobs}
+      deleteItems={env.ALLOW_INFO_PURGE ? deleteProvisioningJobs : undefined}
     />
   );
 }

--- a/components/saml-info-button.tsx
+++ b/components/saml-info-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InfoButton } from "@/components/info-button";
+import { env } from "@/env";
 import { listSamlProfiles } from "@/lib/info";
 import { deleteSamlProfiles } from "@/lib/workflow/info-actions";
 
@@ -9,7 +10,7 @@ export function SamlInfoButton() {
     <InfoButton
       title="Existing SAML Profiles"
       fetchItems={listSamlProfiles}
-      deleteItems={deleteSamlProfiles}
+      deleteItems={env.ALLOW_INFO_PURGE ? deleteSamlProfiles : undefined}
     />
   );
 }

--- a/components/sso-info-button.tsx
+++ b/components/sso-info-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InfoButton } from "@/components/info-button";
+import { env } from "@/env";
 import { listSsoAssignments } from "@/lib/info";
 import { deleteSsoAssignments } from "@/lib/workflow/info-actions";
 
@@ -9,7 +10,7 @@ export function SsoInfoButton() {
     <InfoButton
       title="Existing SSO Assignments"
       fetchItems={listSsoAssignments}
-      deleteItems={deleteSsoAssignments}
+      deleteItems={env.ALLOW_INFO_PURGE ? deleteSsoAssignments : undefined}
     />
   );
 }

--- a/env.ts
+++ b/env.ts
@@ -10,16 +10,22 @@ export const env = createEnv({
     GOOGLE_OAUTH_CLIENT_ID: z.string(),
     GOOGLE_OAUTH_CLIENT_SECRET: z.string(),
     MICROSOFT_OAUTH_CLIENT_ID: z.string(),
-    MICROSOFT_OAUTH_CLIENT_SECRET: z.string(),
-    ALLOW_INFO_PURGE: z
-      .preprocess((v) => (v === "true" ? true : v === "false" ? false : v), z.boolean())
-      .default(false)
+    MICROSOFT_OAUTH_CLIENT_SECRET: z.string()
   },
   client: {},
   shared: {
     NODE_ENV: z
       .enum(["development", "test", "production"])
-      .default("development")
+      .default("development"),
+    ALLOW_INFO_PURGE: z
+      .preprocess(
+        (v) =>
+          v === "true" ? true
+          : v === "false" ? false
+          : v,
+        z.boolean()
+      )
+      .default(false)
   },
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,


### PR DESCRIPTION
## Summary
- expose `ALLOW_INFO_PURGE` to client environment
- hide delete controls when purge is disabled

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6854be0aacf48322a5c192178b4233e4