### PR TITLE
Fix fetch flattening and cleanup steps

### DIFF
--- a/lib/workflow/step-builder.ts
+++ b/lib/workflow/step-builder.ts
@@ -34,30 +34,30 @@ interface HttpClient {
   get<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    options?: { flatten?: boolean }
+    options?: { flatten?: boolean | string }
   ): Promise<R>;
   post<R>(
     url: string,
     schema: z.ZodSchema<R>,
     body?: unknown,
-    options?: { flatten?: boolean }
+    options?: { flatten?: boolean | string }
   ): Promise<R>;
   put<R>(
     url: string,
     schema: z.ZodSchema<R>,
     body?: unknown,
-    options?: { flatten?: boolean }
+    options?: { flatten?: boolean | string }
   ): Promise<R>;
   patch<R>(
     url: string,
     schema: z.ZodSchema<R>,
     body?: unknown,
-    options?: { flatten?: boolean }
+    options?: { flatten?: boolean | string }
   ): Promise<R>;
   delete<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    options?: { flatten?: boolean }
+    options?: { flatten?: boolean | string }
   ): Promise<R>;
 }
 
@@ -172,7 +172,7 @@ function createHttpClient(
   fetchFn: <R>(
     url: string,
     schema: z.ZodSchema<R>,
-    init?: RequestInit & { flatten?: boolean }
+    init?: RequestInit & { flatten?: boolean | string }
   ) => Promise<R>
 ): HttpClient {
   return {

--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -61,7 +61,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
         const { inboundSsoAssignments = [] } = await google.get(
           ApiEndpoint.Google.SsoAssignments,
           AssignSchema,
-          { flatten: true }
+          { flatten: "inboundSsoAssignments" }
         );
         // Extract: assignmentExists = inboundSsoAssignments.some(...)
 
@@ -192,7 +192,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
       const { inboundSsoAssignments = [] } = await google.get(
         ApiEndpoint.Google.SsoAssignments,
         AssignSchema,
-        { flatten: true }
+        { flatten: "inboundSsoAssignments" }
       );
       // Extract: assignmentName = inboundSsoAssignments.find(...).name
 

--- a/lib/workflow/steps/configure-google-saml-profile.ts
+++ b/lib/workflow/steps/configure-google-saml-profile.ts
@@ -45,7 +45,7 @@ export default defineStep(StepId.ConfigureGoogleSamlProfile)
         const { inboundSamlSsoProfiles = [] } = await google.get(
           ApiEndpoint.Google.SsoProfiles,
           ProfilesSchema,
-          { flatten: true }
+          { flatten: "inboundSamlSsoProfiles" }
         );
         // Extract: samlProfileId = inboundSamlSsoProfiles[0]?.name
 

--- a/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
+++ b/lib/workflow/steps/configure-microsoft-sync-and-sso.ts
@@ -45,7 +45,7 @@ export default defineStep(StepId.ConfigureMicrosoftSyncAndSso)
         const { value } = await microsoft.get(
           ApiEndpoint.Microsoft.SyncJobs(spId),
           JobsSchema,
-          { flatten: true }
+          { flatten: "value" }
         );
         // Extract: jobStatusCodes = value.map(v => v.status.code)
 
@@ -135,7 +135,7 @@ export default defineStep(StepId.ConfigureMicrosoftSyncAndSso)
       const { value } = await microsoft.get(
         ApiEndpoint.Microsoft.SyncJobs(spId),
         JobsSchema,
-        { flatten: true }
+        { flatten: "value" }
       );
 
       for (const job of value) {

--- a/lib/workflow/steps/create-microsoft-apps.ts
+++ b/lib/workflow/steps/create-microsoft-apps.ts
@@ -59,14 +59,14 @@ export default defineStep(StepId.CreateMicrosoftApps)
         const { value: provApps } = await microsoft.get(
           `${ApiEndpoint.Microsoft.Applications}?$filter=${provFilter}`,
           AppsSchema,
-          { flatten: true }
+          { flatten: "value" }
         );
         // Extract: provisioning app info from provApps[0]
 
         const { value: ssoApps } = await microsoft.get(
           `${ApiEndpoint.Microsoft.Applications}?$filter=${ssoFilter}`,
           AppsSchema,
-          { flatten: true }
+          { flatten: "value" }
         );
         // Extract: ssoAppId = ssoApps[0]?.appId
 
@@ -85,14 +85,14 @@ export default defineStep(StepId.CreateMicrosoftApps)
           const provRes = await microsoft.get(
             `${ApiEndpoint.Microsoft.ServicePrincipals}?$filter=${provFilter}`,
             SpSchema,
-            { flatten: true }
+            { flatten: "value" }
           );
           // Extract: provisioningServicePrincipalId = provRes.value[0]?.id
 
           const ssoRes = await microsoft.get(
             `${ApiEndpoint.Microsoft.ServicePrincipals}?$filter=${ssoFilter}`,
             SpSchema,
-            { flatten: true }
+            { flatten: "value" }
           );
           // Extract: ssoServicePrincipalId = ssoRes.value[0]?.id
 

--- a/lib/workflow/steps/setup-microsoft-claims-policy.ts
+++ b/lib/workflow/steps/setup-microsoft-claims-policy.ts
@@ -49,7 +49,7 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
         const { value } = await microsoft.get(
           ApiEndpoint.Microsoft.ReadClaimsPolicy(spId),
           PoliciesSchema,
-          { flatten: true }
+          { flatten: "value" }
         );
         // Extract: claimsPolicyId = value[0]?.id
 
@@ -114,7 +114,7 @@ export default defineStep(StepId.SetupMicrosoftClaimsPolicy)
           const { value } = await microsoft.get(
             ApiEndpoint.Microsoft.ClaimsPolicies,
             listSchema,
-            { flatten: true }
+            { flatten: "value" }
           );
           policyId = value[0]?.id;
         } else {

--- a/lib/workflow/steps/test-sso-configuration.ts
+++ b/lib/workflow/steps/test-sso-configuration.ts
@@ -6,18 +6,10 @@ export default defineStep(StepId.TestSsoConfiguration)
   .provides()
 
   .check(async ({ markIncomplete }) => {
-    try {
-      markIncomplete("Manual test required", {});
-    } catch {
-      markIncomplete("Manual test required", {});
-    }
+    markIncomplete("Manual test required", {});
   })
   .execute(async ({ markPending }) => {
-    try {
-      markPending("Complete login flow manually");
-    } catch {
-      markPending("Complete login flow manually");
-    }
+    markPending("Complete login flow manually");
   })
   .undo(async ({ markReverted }) => {
     markReverted();

--- a/lib/workflow/steps/verify-primary-domain.ts
+++ b/lib/workflow/steps/verify-primary-domain.ts
@@ -48,7 +48,7 @@ export default defineStep(StepId.VerifyPrimaryDomain)
         const { domains } = await google.get(
           ApiEndpoint.Google.Domains,
           DomainsResponse,
-          { flatten: true }
+          { flatten: "domains" }
         );
         // Extract: primaryDomain = domains.find(d => d.isPrimary)?.domainName
 

--- a/types.ts
+++ b/types.ts
@@ -34,12 +34,12 @@ export interface StepCheckContext<T> {
   fetchGoogle<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    init?: RequestInit & { flatten?: boolean }
+    init?: RequestInit & { flatten?: boolean | string }
   ): Promise<R>;
   fetchMicrosoft<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    init?: RequestInit & { flatten?: boolean }
+    init?: RequestInit & { flatten?: boolean | string }
   ): Promise<R>;
   log(level: LogLevel, message: string, data?: unknown): void;
   vars: Partial<WorkflowVars>;
@@ -52,12 +52,12 @@ export interface StepExecuteContext<T> {
   fetchGoogle<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    init?: RequestInit & { flatten?: boolean }
+    init?: RequestInit & { flatten?: boolean | string }
   ): Promise<R>;
   fetchMicrosoft<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    init?: RequestInit & { flatten?: boolean }
+    init?: RequestInit & { flatten?: boolean | string }
   ): Promise<R>;
   log(level: LogLevel, message: string, data?: unknown): void;
   vars: Partial<WorkflowVars>;
@@ -71,12 +71,12 @@ export interface StepUndoContext {
   fetchGoogle<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    init?: RequestInit & { flatten?: boolean }
+    init?: RequestInit & { flatten?: boolean | string }
   ): Promise<R>;
   fetchMicrosoft<R>(
     url: string,
     schema: z.ZodSchema<R>,
-    init?: RequestInit & { flatten?: boolean }
+    init?: RequestInit & { flatten?: boolean | string }
   ): Promise<R>;
   log(level: LogLevel, message: string, data?: unknown): void;
   vars: Partial<WorkflowVars>;


### PR DESCRIPTION
## Summary
- broaden `flatten` option for fetch utils
- support string property in step builder interfaces
- use explicit property name when flattening API responses
- simplify manual SSO test step

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6854cbe695988322b16459a86f0ccfcd