### PR TITLE
Fix key usage and provider redirect

### DIFF
--- a/components/provider-login.tsx
+++ b/components/provider-login.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import { type Provider } from "@/constants";
 import { Var, WorkflowVars } from "@/types";
 import { CheckCircle, XCircle } from "lucide-react";
-import { redirect } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 interface Props {
@@ -127,7 +126,7 @@ export function ProviderLogin({ onUpdate }: Props) {
         Icon={Microsoft}
         name="Microsoft"
         isConnected={tokens.msGraphToken !== undefined}
-        onConnectClick={() => redirect("/api/auth/microsoft")}
+        onConnectClick={() => (window.location.href = "/api/auth/microsoft")}
         onDisconnectClick={() => signOut("microsoft")}
         iconColorClass="text-purple-500"
       />

--- a/components/step-api-calls.tsx
+++ b/components/step-api-calls.tsx
@@ -64,8 +64,8 @@ export function StepApiCalls({ stepId }: StepApiCallsProps) {
 
   return (
     <div className="space-y-3">
-      {apiTemplates.map((template, idx) => (
-        <TooltipProvider key={idx}>
+      {apiTemplates.map((template) => (
+        <TooltipProvider key={template.endpoint}>
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="border border-slate-200 rounded-lg p-3 bg-slate-50/30 hover:bg-slate-100/50 transition-colors duration-150 cursor-help">

--- a/components/step-logs.tsx
+++ b/components/step-logs.tsx
@@ -63,9 +63,9 @@ export function StepLogs({ logs }: StepLogsProps) {
   return (
     <ScrollArea className="h-[250px] -mx-2">
       <div className="space-y-1.5 px-2">
-        {logs.map((log, index) => (
+        {logs.map((log) => (
           <div
-            key={index}
+            key={log.timestamp}
             className="p-3 rounded-md border bg-white border-slate-200">
             <div className="flex items-start gap-3">
               <div


### PR DESCRIPTION
## Summary
- avoid unstable array indices for StepLogs and StepApiCalls
- remove server-only `redirect` in ProviderLogin

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6854dc715c048322b9cda432ae3f0cd5