### PR TITLE
Improve tooltip and card behavior

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -126,6 +126,22 @@
   .animate-indeterminate {
     animation: indeterminate 1.5s linear infinite;
   }
+
+  .api-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) var(--muted);
+  }
+  .api-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .api-scrollbar::-webkit-scrollbar-track {
+    background: var(--muted);
+  }
+  .api-scrollbar::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 3px;
+  }
 }
 
 @layer base {

--- a/components/info-button.tsx
+++ b/components/info-button.tsx
@@ -207,6 +207,7 @@ export function InfoButton({
         <Button
           size="sm"
           variant="outline"
+          onClick={(e) => e.stopPropagation()}
           className="border-slate-300 text-slate-700">
           <Info className="h-3.5 w-3.5 mr-1.5" /> Info
         </Button>

--- a/components/step-api-calls.tsx
+++ b/components/step-api-calls.tsx
@@ -63,35 +63,33 @@ export function StepApiCalls({ stepId }: StepApiCallsProps) {
   };
 
   return (
-    <div className="space-y-3" onClick={(e) => e.stopPropagation()}>
-      {apiTemplates.map((template) => (
-        <TooltipProvider key={template.endpoint}>
+    <div className="space-y-1 text-xs" onClick={(e) => e.stopPropagation()}>
+      {apiTemplates.map((template, idx) => (
+        <TooltipProvider key={idx}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="border border-slate-200 rounded-lg p-3 bg-slate-50/30 hover:bg-slate-100/50 transition-colors duration-150 cursor-help">
-                <div className="flex items-start gap-3">
-                  <div className="flex-shrink-0">
-                    {getMethodBadge(template.method)}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-slate-800 mb-1">
-                      {template.description}
-                    </p>
-                    <code className="text-xs text-slate-600 bg-white px-2 py-1 rounded border border-slate-300 break-all">
-                      {template.endpoint}
-                    </code>
-                  </div>
+              <div className="flex items-start gap-2 rounded px-2 py-1 hover:bg-slate-100 cursor-help">
+                <div className="flex-shrink-0 mt-0.5">
+                  {getMethodBadge(template.method)}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <span className="font-medium text-slate-800">
+                    {template.description}
+                  </span>
+                  <code className="ml-1 text-slate-600 break-all">
+                    {template.endpoint}
+                  </code>
                 </div>
               </div>
             </TooltipTrigger>
 
-            <TooltipContent side="bottom" className="max-w-md">
-              <div className="space-y-2">
-                <pre className="text-xs bg-slate-800 text-slate-100 p-2 rounded overflow-auto max-h-40">
-                  <strong>{getFullUrl(template.endpoint)}</strong>
-                  {JSON.stringify(template.body, null, 2)}
-                </pre>
-              </div>
+            <TooltipContent side="bottom" className="max-w-lg w-96">
+              <pre className="api-scrollbar text-[11px] bg-slate-800 text-slate-100 p-2 rounded max-h-40 overflow-auto">
+                <strong className="block mb-1">
+                  {getFullUrl(template.endpoint)}
+                </strong>
+                {JSON.stringify(template.body, null, 2)}
+              </pre>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -199,7 +199,8 @@ export function StepCard({
 
   const getCardClassName = () => {
     const baseClass =
-      "transition-all duration-300 ease-out bg-white border cursor-pointer py-4";
+      "transition-all duration-300 ease-out bg-white border py-4";
+    const cursorClass = isExpanded ? "" : "cursor-pointer";
     const shadowClass = isExpanded ? "shadow-xl" : "hover:shadow-lg";
     let borderColorClass = "border-slate-200 hover:border-slate-300";
     const animationClass = "";
@@ -225,7 +226,7 @@ export function StepCard({
           break;
       }
     }
-    return `${baseClass} ${shadowClass} ${borderColorClass} ${animationClass}`;
+    return `${baseClass} ${cursorClass} ${shadowClass} ${borderColorClass} ${animationClass}`;
   };
 
   const canExecute = Object.entries(WORKFLOW_VARIABLES)
@@ -242,7 +243,9 @@ export function StepCard({
   return (
     <Card
       className={getCardClassName()}
-      onClick={handleHeaderClick}
+      onClick={() => {
+        if (!isExpanded) handleHeaderClick();
+      }}
       role="button"
       aria-expanded={isExpanded}>
       <CardHeader


### PR DESCRIPTION
## Summary
- use array index as tooltip key
- style API calls inline and widen tooltip
- prevent info dialogs from collapsing step
- make collapsed cards clickable but disable when expanded
- style tooltip scrollbars

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685578774afc8322b3f76c112ffaa961