### PR TITLE
Fix purge all progress feedback

### DIFF
--- a/components/info-button.tsx
+++ b/components/info-button.tsx
@@ -273,15 +273,27 @@ export function InfoButton({
                     onChange={(e) => setDeleteConfirmText(e.target.value)}
                     placeholder="Type DELETE ALL to confirm"
                     className="mt-2"
+                    disabled={isDeleting}
                   />
                   <AlertDialogFooter>
-                    <AlertDialogCancel onClick={() => setDeleteConfirmText("")}>
+                    <AlertDialogCancel
+                      onClick={() => setDeleteConfirmText("")}
+                      disabled={isDeleting}>
                       Cancel
                     </AlertDialogCancel>
                     <AlertDialogAction
-                      onClick={handlePurgeAll}
-                      disabled={deleteConfirmText !== "DELETE ALL"}
+                      onClick={async (e) => {
+                        e.preventDefault();
+                        await handlePurgeAll();
+                        setOpen(false);
+                      }}
+                      disabled={
+                        deleteConfirmText !== "DELETE ALL" || isDeleting
+                      }
                       className="bg-red-600 hover:bg-red-700">
+                      {isDeleting && (
+                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                      )}
                       Purge All
                     </AlertDialogAction>
                   </AlertDialogFooter>


### PR DESCRIPTION
## Summary
- keep purge confirmation dialog open while deleting
- disable inputs and show spinner until purge completes

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68557d39867883229d7498fefcce458c