### PR TITLE
docs: expand AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,27 @@ pnpm build
 ```
 
 These commands should run without any warnings or TypeScript errors.
+
+## ✅ Token Verification
+
+Bearer tokens for Google and Microsoft live under `google_bearer.token` and
+`microsoft_bearer.token`. Before running steps or E2E tests, verify they are
+valid:
+
+```bash
+./scripts/token-info.sh
+```
+
+The script prints token metadata so you know the credentials are active.
+Never commit refreshed tokens or other secrets to the repository.
+
+## ✅ Testing
+
+Unit and integration tests can be run with:
+
+```bash
+pnpm test
+```
+
+E2E tests require `TEST_GOOGLE_BEARER_TOKEN`, `TEST_MS_BEARER_TOKEN` and
+`TEST_DOMAIN` environment variables. Set `RUN_E2E=1` to enable them.

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Guidelines
+
+- Export all React components using **named exports**. No `default` exports.
+- Add `"use client"` at the top of components that use state or effects.
+- Use `cn()` from `@/lib/utils` to compose Tailwind class names.
+- Prefer primitives from `components/ui/` over custom styling.
+- Keep component props typed and avoid `any`.

--- a/lib/workflow/steps/AGENTS.md
+++ b/lib/workflow/steps/AGENTS.md
@@ -39,6 +39,10 @@ Every step MUST follow this exact pattern:
 6. Define Zod schemas inline before API calls (never use `z.any()`).
 7. You do _not_ need manual token/var checks—`defineStep` automatically fails
    the check if any declared `requires` variable is missing.
+8. Document the HTTP requests and responses your step performs using block
+   comments above each `check()` and `execute()` section.
+9. Provide an `.undo()` handler for any step that mutates remote state so tests
+   can clean up after themselves.
 
 ### Environment Variables in Steps
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,7 @@
+# Script Guidelines
+
+- Shell scripts should start with `#!/usr/bin/env bash` and `set -euo pipefail`.
+- Node scripts are written in TypeScript and run with `pnpm tsx`.
+- Scripts expect bearer tokens via environment variables or token files.
+- Do not embed real credentials or tenant IDs directly in scripts.
+- Use the constants in `constants.ts` for API endpoints.

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -1,0 +1,7 @@
+# E2E Test Notes
+
+- Tests require `TEST_GOOGLE_BEARER_TOKEN`, `TEST_MS_BEARER_TOKEN` and
+  `TEST_DOMAIN` environment variables.
+- Set `RUN_E2E=1` when invoking `pnpm test` to enable the live tests.
+- Fixtures live under `test/e2e/fixtures/`. Use `UPDATE_FIXTURES=1` to
+  regenerate them and `CHECK_FIXTURES=1` to assert against them.


### PR DESCRIPTION
## Summary
- expand root AGENTS docs with token verification and testing info
- add more implementation rules in `lib/workflow/steps/AGENTS.md`
- create AGENTS guidelines for components, scripts and e2e tests

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685596abb9f4832294448da11197beb5