### PR TITLE
Fix duplicate key in StepLogs

### DIFF
--- a/components/step-logs.tsx
+++ b/components/step-logs.tsx
@@ -123,8 +123,8 @@ export function StepLogs({ logs }: StepLogsProps) {
       className="h-[250px] -mx-2"
       onClick={(e) => e.stopPropagation()}>
       <div className="space-y-1.5 px-2">
-        {logs.map((log) => (
-          <StepLogItem key={log.timestamp} log={log} />
+        {logs.map((log, index) => (
+          <StepLogItem key={index} log={log} />
         ))}
       </div>
     </ScrollArea>


### PR DESCRIPTION
## Summary
- avoid duplicate React keys in StepLogs by using array index

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68559ade641883228a632ade26f3719f