### PR TITLE
Add progress indicator and automatic log display

### DIFF
--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -85,6 +85,13 @@ export function StepCard({
     }
   }, [isExpanded]);
 
+  useEffect(() => {
+    if (executing || state?.status === "pending") {
+      setIsExpanded(true);
+      setLogsOpen(true);
+    }
+  }, [executing, state?.status]);
+
   const getStepIndexDisplay = () => {
     const baseClasses =
       "flex items-center justify-center w-7 h-7 rounded-full text-xs font-semibold flex-shrink-0 transition-colors duration-200";
@@ -307,6 +314,14 @@ export function StepCard({
           </div>
         )}
       </CardHeader>
+
+      {(executing || state?.status === "pending") && (
+        <div className="px-6">
+          <div className="relative h-1 bg-slate-200 overflow-hidden rounded">
+            <div className="absolute inset-0 bg-blue-500 animate-indeterminate" />
+          </div>
+        </div>
+      )}
 
       <Collapsible open={isExpanded}>
         <CollapsibleContent className="overflow-hidden transition-all duration-300 ease-out data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">

--- a/components/step-logs.tsx
+++ b/components/step-logs.tsx
@@ -91,7 +91,7 @@ function StepLogItem({ log }: { log: StepLogEntry }) {
         </div>
       </CollapsibleTrigger>
       {log.data !== null && (
-        <CollapsibleContent className="mt-2 animate-accordion-down">
+        <CollapsibleContent className="mt-2 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
           <div className="bg-slate-800 text-slate-100 rounded p-2.5 border border-slate-700 max-h-60 overflow-y-auto">
             <pre className="text-xs font-mono whitespace-pre-wrap">
               {JSON.stringify(log.data, null, 2)}


### PR DESCRIPTION
## Summary
- show animated progress bar when executing or pending
- auto-expand step and logs while executing
- animate log item collapsible closing

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855a59e68208322962bdea23a17a8cb