### PR TITLE
Update StepCard descriptor text

### DIFF
--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -85,6 +85,18 @@ export function StepCard({
     }
   }, [isExpanded]);
 
+  const getDescriptorText = () => {
+    if (executing) return "Executing...";
+    switch (state?.status) {
+      case "checking":
+        return "Checking...";
+      case "undoing":
+        return "Undoing...";
+      default:
+        return state?.summary || "Ready to execute";
+    }
+  };
+
   const getStepIndexDisplay = () => {
     const baseClasses =
       "flex items-center justify-center w-7 h-7 rounded-full text-xs font-semibold flex-shrink-0 transition-colors duration-200";
@@ -280,7 +292,7 @@ export function StepCard({
                 {title}
               </h3>
               <p className="text-xs md:text-sm text-slate-600 mt-0.5 leading-tight">
-                {state?.summary || "Ready to execute"}
+                {getDescriptorText()}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show 'Executing...', 'Checking...', or 'Undoing...' under step title when a step is active

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855a55393fc8322b3b16de52324587e