### PR TITLE
Fix SSO assignment cleanup

### DIFF
--- a/lib/info.ts
+++ b/lib/info.ts
@@ -105,15 +105,18 @@ export async function listSsoAssignments(): Promise<InfoItem[]> {
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = Schema.parse(await res.json());
   return (
-    data.inboundSsoAssignments?.map((a) => ({
-      id: a.name,
-      label: a.targetGroup || a.targetOrgUnit || a.name,
-      href: undefined,
-      deletable: true,
-      deleteEndpoint: `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(
-        a.name
-      )}`
-    })) ?? []
+    data.inboundSsoAssignments?.map((a) => {
+      const id = a.name.replace(/^(?:.*\/)?inboundSsoAssignments\//, "");
+      return {
+        id,
+        label: a.targetGroup || a.targetOrgUnit || a.name,
+        href: undefined,
+        deletable: true,
+        deleteEndpoint: `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(
+          id
+        )}`
+      };
+    }) ?? []
   );
 }
 

--- a/lib/workflow/info-actions.ts
+++ b/lib/workflow/info-actions.ts
@@ -115,10 +115,10 @@ export async function deleteSamlProfiles(ids: string[]): Promise<DeleteResult> {
 export async function deleteSsoAssignments(
   ids: string[]
 ): Promise<DeleteResult> {
-  return createGoogleDeleteAction(
-    (id) => `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(id)}`,
-    "SSO Assignment"
-  )(ids);
+  return createGoogleDeleteAction((id) => {
+    const normalized = id.replace(/^(?:.*\/)?inboundSsoAssignments\//, "");
+    return `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(normalized)}`;
+  }, "SSO Assignment")(ids);
 }
 
 export async function deleteGoogleRoles(ids: string[]): Promise<DeleteResult> {

--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -203,8 +203,12 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
       );
 
       if (assignment) {
+        const id = assignment.name.replace(
+          /^(?:.*\/)?inboundSsoAssignments\//,
+          ""
+        );
         await google.delete(
-          `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(assignment.name)}`,
+          `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(id)}`,
           EmptyResponseSchema
         );
       }

--- a/scripts/full-cleanup.ts
+++ b/scripts/full-cleanup.ts
@@ -51,8 +51,9 @@ async function cleanupGoogleAssignments() {
   const { inboundSsoAssignments = [] } = AssignSchema.parse(await res.json());
 
   for (const assign of inboundSsoAssignments) {
+    const id = assign.name.replace(/^(?:.*\/)?inboundSsoAssignments\//, "");
     await fetch(
-      `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(assign.name)}`,
+      `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(id)}`,
       { method: "DELETE", headers: { Authorization: `Bearer ${GOOGLE_TOKEN}` } }
     );
   }

--- a/test/info/fixtures/google-sso-assignments-prefixed.json
+++ b/test/info/fixtures/google-sso-assignments-prefixed.json
@@ -1,0 +1,8 @@
+{
+  "inboundSsoAssignments": [
+    {
+      "name": "inboundSsoAssignments/abc123",
+      "targetOrgUnit": "orgUnits/03ph8a2z23yjui6"
+    }
+  ]
+}

--- a/test/info/info.test.ts
+++ b/test/info/info.test.ts
@@ -99,6 +99,26 @@ describe("info server actions", () => {
     ]);
   });
 
+  test("listSsoAssignments handles prefixed names", async () => {
+    global.fetch = jest
+      .fn<() => Promise<any>>()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => load("google-sso-assignments-prefixed.json")
+      }) as any;
+    const items = await listSsoAssignments();
+    expect(items).toEqual([
+      {
+        id: "abc123",
+        label: "orgUnits/03ph8a2z23yjui6",
+        href: undefined,
+        deletable: true,
+        deleteEndpoint:
+          "https://cloudidentity.googleapis.com/v1/inboundSsoAssignments/abc123"
+      }
+    ]);
+  });
+
   test("listProvisioningJobs", async () => {
     global.fetch = jest
       .fn<() => Promise<any>>()


### PR DESCRIPTION
## Summary
- fix list/delete logic for SSO assignments with full resource names
- support deleting SSO assignments with prefixed names in info actions and workflow step
- update cleanup script accordingly
- test SSO assignment listing with prefixed names

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855a6b6f5f88322bce9dcd5fdaaca18