### PR TITLE
Improve collapsible animations

### DIFF
--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -337,7 +337,7 @@ export function StepCard({
       )}
 
       <Collapsible open={isExpanded}>
-        <CollapsibleContent className="overflow-hidden transition-all duration-300 ease-out data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+        <CollapsibleContent className="overflow-hidden origin-top transform-gpu transition-transform duration-300 data-[state=closed]:scale-y-0 data-[state=open]:scale-y-100">
           <CardContent className="px-6">
             {/* Action Buttons */}
             {detail?.description && (
@@ -435,7 +435,7 @@ export function StepCard({
                   }`}
                 />
               </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+              <CollapsibleContent className="mt-2 origin-top transform-gpu transition-transform duration-300 data-[state=closed]:scale-y-0 data-[state=open]:scale-y-100">
                 {state?.logs && state.logs.length > 0 ?
                   <StepLogs logs={state.logs} />
                 : <div className="text-center py-6 text-slate-500 border border-dashed border-slate-300 rounded-lg mt-1">

--- a/components/step-logs.tsx
+++ b/components/step-logs.tsx
@@ -91,7 +91,7 @@ function StepLogItem({ log }: { log: StepLogEntry }) {
         </div>
       </CollapsibleTrigger>
       {log.data !== null && (
-        <CollapsibleContent className="mt-2 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+        <CollapsibleContent className="mt-2 origin-top transform-gpu transition-transform duration-300 data-[state=closed]:scale-y-0 data-[state=open]:scale-y-100">
           <div className="bg-slate-800 text-slate-100 rounded p-2.5 border border-slate-700 max-h-60 overflow-y-auto">
             <pre className="text-xs font-mono whitespace-pre-wrap">
               {JSON.stringify(log.data, null, 2)}


### PR DESCRIPTION
## Summary
- tweak step card and log item collapsible content classes to use transform-based scale animations

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855aa2350e08322bb3e173544a44a02