### PR TITLE
Improve info item details

### DIFF
--- a/components/info-button.tsx
+++ b/components/info-button.tsx
@@ -35,6 +35,7 @@ import { useCallback, useEffect, useState } from "react";
 export interface InfoItem {
   id: string;
   label: string;
+  subLabel?: string;
   href?: string;
   deletable?: boolean;
 }
@@ -340,6 +341,11 @@ export function InfoButton({
                         {item.label}
                       </span>
                     }
+                    {item.subLabel && (
+                      <span className="text-xs text-slate-500 truncate block">
+                        {item.subLabel}
+                      </span>
+                    )}
                     {failedDeletes.has(item.id) && (
                       <span className="text-xs text-red-600">
                         Failed: {failedDeletes.get(item.id)}

--- a/test/info/fixtures/google-sso-assignments-prefixed.json
+++ b/test/info/fixtures/google-sso-assignments-prefixed.json
@@ -2,7 +2,8 @@
   "inboundSsoAssignments": [
     {
       "name": "inboundSsoAssignments/abc123",
-      "targetOrgUnit": "orgUnits/03ph8a2z23yjui6"
+      "targetOrgUnit": "orgUnits/03ph8a2z23yjui6",
+      "ssoMode": "SSO_OFF"
     }
   ]
 }

--- a/test/info/fixtures/google-sso-assignments.json
+++ b/test/info/fixtures/google-sso-assignments.json
@@ -1,5 +1,9 @@
 {
   "inboundSsoAssignments": [
-    { "name": "assignments/allUsers", "targetGroup": "groups/allUsers" }
+    {
+      "name": "assignments/allUsers",
+      "targetGroup": "groups/allUsers",
+      "ssoMode": "SAML_SSO"
+    }
   ]
 }

--- a/test/info/fixtures/ms-sync-jobs.json
+++ b/test/info/fixtures/ms-sync-jobs.json
@@ -1,1 +1,5 @@
-{ "value": [{ "id": "Initial", "status": { "code": "Active" } }] }
+{
+  "value": [
+    { "id": "Initial", "templateId": "gsuite", "status": { "code": "Active" } }
+  ]
+}

--- a/test/info/info.test.ts
+++ b/test/info/info.test.ts
@@ -71,7 +71,7 @@ describe("info server actions", () => {
       {
         id: "samlProfiles/abc123",
         label: "Workspace SAML",
-        href: undefined,
+        href: "https://admin.google.com/ac/apps/saml/abc123",
         deletable: true,
         deleteEndpoint:
           "https://cloudidentity.googleapis.com/v1/inboundSamlSsoProfiles/samlProfiles%2Fabc123"
@@ -91,7 +91,8 @@ describe("info server actions", () => {
       {
         id: "assignments/allUsers",
         label: "groups/allUsers",
-        href: undefined,
+        subLabel: "SAML_SSO",
+        href: "https://admin.google.com/ac/security/inboundsso?assignmentId=assignments%2FallUsers",
         deletable: true,
         deleteEndpoint:
           "https://cloudidentity.googleapis.com/v1/inboundSsoAssignments/assignments%2FallUsers"
@@ -111,7 +112,8 @@ describe("info server actions", () => {
       {
         id: "abc123",
         label: "orgUnits/03ph8a2z23yjui6",
-        href: undefined,
+        subLabel: "SSO_OFF",
+        href: "https://admin.google.com/ac/security/inboundsso?assignmentId=abc123",
         deletable: true,
         deleteEndpoint:
           "https://cloudidentity.googleapis.com/v1/inboundSsoAssignments/abc123"
@@ -134,8 +136,9 @@ describe("info server actions", () => {
     expect(items).toEqual([
       {
         id: "Initial",
-        label: "Active",
-        href: undefined,
+        label: "gsuite",
+        subLabel: "Active",
+        href: "https://entra.microsoft.com/#view/Microsoft_AAD_Connect/SynchronizationJobBlade/jobId/Initial",
         deletable: true,
         deleteEndpoint:
           "https://graph.microsoft.com/v1.0/servicePrincipals/sp1/synchronization/jobs/Initial"


### PR DESCRIPTION
## Summary
- show sub labels in info button rows
- add links and sso state info when listing assignments
- include template and status info for provisioning jobs
- update unit tests for info items

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855a9beca6483228851aab5f3220b3a