### PR TITLE
Add segmented progress bar to header

### DIFF
--- a/components/step-progress.tsx
+++ b/components/step-progress.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useWorkflow } from "./workflow-context";
+import { type StepIdValue } from "@/types";
+
+export function StepProgress() {
+  const { steps, status, executing } = useWorkflow();
+
+  const getColor = (stepId: StepIdValue) => {
+    const state = status[stepId];
+    if (executing === stepId) return "bg-blue-500";
+    switch (state?.status) {
+      case "checking":
+      case "executing":
+        return "bg-blue-500";
+      case "complete":
+        return "bg-green-500";
+      case "failed":
+        return "bg-red-500";
+      case "pending":
+      case "undoing":
+        return "bg-amber-500";
+      case "reverted":
+        return "bg-slate-600";
+      default:
+        return "bg-slate-200";
+    }
+  };
+
+  return (
+    <div className="flex gap-0.5 mt-1 h-2">
+      {steps.map((step, index) => (
+        <div
+          key={step.id}
+          className={cn(
+            "flex-1 rounded-sm",
+            index === 0 && "rounded-l",
+            index === steps.length - 1 && "rounded-r",
+            getColor(step.id)
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/workflow-header.tsx
+++ b/components/workflow-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ProviderLogin } from "@/components/provider-login";
+import { StepProgress } from "@/components/step-progress";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { useWorkflow } from "./workflow-context";
@@ -28,17 +29,16 @@ export function WorkflowHeader() {
             <h1 className="text-xl font-semibold text-blue-700">Easy CEP</h1>
           </div>
           <div className="flex items-center gap-3 text-sm -mx-1">
-            <Badge
-              variant={isRunning ? "default" : "secondary"}
-              className={
-                isRunning ? "bg-green-100 text-green-800 border-green-200" : ""
-              }>
-              {isRunning ? "Running" : "Idle"}
-            </Badge>
+            {isRunning && (
+              <Badge className="bg-green-100 text-green-800 border-green-200">
+                Running
+              </Badge>
+            )}
             <span className="text-slate-600">
               {completedSteps}/{steps.length} steps completed
             </span>
           </div>
+          <StepProgress />
         </div>
         <ProviderLogin onUpdate={updateVars} />
       </div>


### PR DESCRIPTION
## Summary
- show step-by-step progress in the header
- color code each step

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855aa4855488322a4c6acf3580922c6