### PR TITLE
Fix SSO assignment endpoint

### DIFF
--- a/lib/info.ts
+++ b/lib/info.ts
@@ -99,9 +99,10 @@ export async function listSsoAssignments(): Promise<InfoItem[]> {
       .optional()
   });
 
-  const res = await fetch(ApiEndpoint.Google.SsoAssignments, {
-    headers: { Authorization: `Bearer ${token.accessToken}` }
-  });
+  const res = await fetch(
+    `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
+    { headers: { Authorization: `Bearer ${token.accessToken}` } }
+  );
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = Schema.parse(await res.json());
   return (

--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -59,7 +59,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
         const profileId = vars.require(Var.SamlProfileId);
 
         const { inboundSsoAssignments = [] } = await google.get(
-          ApiEndpoint.Google.SsoAssignments,
+          `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
           AssignSchema,
           { flatten: "inboundSsoAssignments" }
         );
@@ -136,7 +136,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
        * { "error": { "code": 409, "message": "Assignment exists" } }
        */
       const op = await google.post(
-        ApiEndpoint.Google.SsoAssignments,
+        `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
         OpSchema,
         {
           targetGroup: `groups/${GroupId.AllUsers}`,
@@ -190,7 +190,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
       });
 
       const { inboundSsoAssignments = [] } = await google.get(
-        ApiEndpoint.Google.SsoAssignments,
+        `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
         AssignSchema,
         { flatten: "inboundSsoAssignments" }
       );


### PR DESCRIPTION
## Summary
- pass `customer` parameter to inboundSsoAssignments API
- use the same parameter when listing SSO assignments

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855aaa579a48322a415283cdeea0ed6