### PR TITLE
Improve step log display

### DIFF
--- a/components/step-api-calls.tsx
+++ b/components/step-api-calls.tsx
@@ -7,7 +7,8 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from "@/components/ui/tooltip";
-import { ApiEndpoint } from "@/constants";
+import { API_PREFIXES, ApiEndpoint } from "@/constants";
+import { extractPath } from "@/lib/utils/url";
 import { Var } from "@/types";
 
 type StepIdValue = string;
@@ -28,19 +29,27 @@ export function StepApiCalls({ stepId }: StepApiCallsProps) {
   if (apiTemplates.length === 0) return null;
 
   const getFullUrl = (endpoint: string) => {
+    const {
+      GOOGLE_ADMIN,
+      GOOGLE_CLOUD_IDENTITY,
+      MS_GRAPH,
+      MS_GRAPH_BETA,
+      MS_GRAPH_V1
+    } = API_PREFIXES;
+
     if (endpoint.startsWith("/cloudidentity")) {
-      return `https://cloudidentity.googleapis.com/v1${endpoint.slice("/cloudidentity".length)}`;
+      return GOOGLE_CLOUD_IDENTITY + endpoint.slice("/cloudidentity".length);
     }
     if (endpoint.startsWith("/graph/beta")) {
-      return `https://graph.microsoft.com${endpoint.slice("/graph".length)}`;
+      return MS_GRAPH_BETA + endpoint.slice("/graph/beta".length);
     }
     if (endpoint.startsWith("/graph/v1.0")) {
-      return `https://graph.microsoft.com${endpoint.slice("/graph".length)}`;
+      return MS_GRAPH_V1 + endpoint.slice("/graph/v1.0".length);
     }
     if (endpoint.startsWith("/graph")) {
-      return `https://graph.microsoft.com${endpoint.slice("/graph".length)}`;
+      return MS_GRAPH + endpoint.slice("/graph".length);
     }
-    return `https://admin.googleapis.com/admin/directory/v1${endpoint}`;
+    return GOOGLE_ADMIN + endpoint;
   };
 
   const getMethodBadge = (method: string) => {
@@ -94,26 +103,6 @@ export function StepApiCalls({ stepId }: StepApiCallsProps) {
       ))}
     </div>
   );
-}
-
-function extractPath(url: string): string {
-  // eslint-disable-next-line workflow/no-hardcoded-urls
-  const googlePrefix = "https://admin.googleapis.com/admin/directory/v1";
-  // eslint-disable-next-line workflow/no-hardcoded-urls
-  const googleCloudPrefix = "https://cloudidentity.googleapis.com/v1";
-  // eslint-disable-next-line workflow/no-hardcoded-urls
-  const msGraphPrefix = "https://graph.microsoft.com";
-
-  if (url.startsWith(googlePrefix)) {
-    return url.slice(googlePrefix.length);
-  }
-  if (url.startsWith(googleCloudPrefix)) {
-    return "/cloudidentity" + url.slice(googleCloudPrefix.length);
-  }
-  if (url.startsWith(msGraphPrefix)) {
-    return "/graph" + url.slice(msGraphPrefix.length);
-  }
-  return url;
 }
 
 export const stepApiMetadata: Record<StepIdValue, ApiCallMetadata[]> = {

--- a/components/step-log-item.tsx
+++ b/components/step-log-item.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger
+} from "@/components/ui/collapsible";
+import { extractPath } from "@/lib/utils/url";
+import { StepLogEntry } from "@/types";
+import { AlertTriangle, Bug, ChevronRight, Info, XCircle } from "lucide-react";
+import { useState } from "react";
+
+interface StepLogItemProps {
+  log: StepLogEntry;
+}
+
+function getLevelIcon(level?: string) {
+  switch (level) {
+    case "warn":
+      return <AlertTriangle className="h-4 w-4 text-amber-500" />;
+    case "error":
+      return <XCircle className="h-4 w-4 text-red-500" />;
+    case "debug":
+      return <Bug className="h-4 w-4 text-purple-500" />;
+    default:
+      return <Info className="h-4 w-4 text-blue-500" />;
+  }
+}
+
+function getLevelBadgeClasses(level?: string) {
+  switch (level) {
+    case "warn":
+      return "bg-amber-50 text-amber-700 border-amber-200";
+    case "error":
+      return "bg-red-50 text-red-700 border-red-200";
+    case "debug":
+      return "bg-purple-50 text-purple-700 border-purple-200";
+    default:
+      return "bg-blue-50 text-blue-700 border-blue-200";
+  }
+}
+
+function getLevelText(level?: string) {
+  return (level || "info").toUpperCase();
+}
+
+function getMethodClasses(success: boolean) {
+  return success ?
+      "bg-green-50 text-green-700 border-green-200"
+    : "bg-red-50 text-red-700 border-red-200";
+}
+
+export function StepLogItem({ log }: StepLogItemProps) {
+  const [open, setOpen] = useState(false);
+  const time = new Date(log.timestamp).toLocaleTimeString();
+
+  if (log.method) {
+    const success = log.status === undefined || log.status < 400;
+    return (
+      <Collapsible
+        open={open}
+        onOpenChange={setOpen}
+        className="p-3 rounded-md border bg-white border-slate-200">
+        <CollapsibleTrigger asChild>
+          <div className="flex items-start gap-3 cursor-pointer">
+            <div className={`p-1.5 rounded ${getMethodClasses(success)}`}>
+              <span className="text-xs font-mono">{log.method}</span>
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1 flex-wrap">
+                {log.status !== undefined && (
+                  <Badge
+                    variant="outline"
+                    className="bg-slate-100 text-slate-700 border-slate-200">
+                    {log.status}
+                  </Badge>
+                )}
+                <span className="text-xs text-slate-500 font-mono bg-slate-100 px-1.5 py-0.5 rounded border border-slate-200">
+                  {time}
+                </span>
+                {log.data !== null && (
+                  <ChevronRight
+                    className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`}
+                  />
+                )}
+              </div>
+              <p className="text-sm text-slate-800 leading-relaxed break-all">
+                {extractPath(log.url ?? "")}
+              </p>
+            </div>
+          </div>
+        </CollapsibleTrigger>
+        {log.data !== null && (
+          <CollapsibleContent className="mt-2 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+            <div className="bg-slate-800 text-slate-100 rounded p-2.5 border border-slate-700 max-h-60 overflow-y-auto">
+              <pre className="text-xs font-mono whitespace-pre-wrap">
+                {JSON.stringify(log.data, null, 2)}
+              </pre>
+            </div>
+          </CollapsibleContent>
+        )}
+      </Collapsible>
+    );
+  }
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="p-3 rounded-md border bg-white border-slate-200">
+      <CollapsibleTrigger asChild>
+        <div className="flex items-start gap-3 cursor-pointer">
+          <div
+            className={`p-1.5 rounded ${getLevelBadgeClasses(log.level).split(" ")[0].replace("bg-", "bg-opacity-20")}`}>
+            {getLevelIcon(log.level)}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1 flex-wrap">
+              <Badge
+                variant="outline"
+                className={`${getLevelBadgeClasses(log.level)} font-semibold`}>
+                {getLevelText(log.level)}
+              </Badge>
+              <span className="text-xs text-slate-500 font-mono bg-slate-100 px-1.5 py-0.5 rounded border border-slate-200">
+                {time}
+              </span>
+              {log.data !== null && (
+                <ChevronRight
+                  className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`}
+                />
+              )}
+            </div>
+            <p className="text-sm text-slate-800 leading-relaxed break-words">
+              {log.message}
+            </p>
+          </div>
+        </div>
+      </CollapsibleTrigger>
+      {log.data !== null && (
+        <CollapsibleContent className="mt-2 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+          <div className="bg-slate-800 text-slate-100 rounded p-2.5 border border-slate-700 max-h-60 overflow-y-auto">
+            <pre className="text-xs font-mono whitespace-pre-wrap">
+              {JSON.stringify(log.data, null, 2)}
+            </pre>
+          </div>
+        </CollapsibleContent>
+      )}
+    </Collapsible>
+  );
+}

--- a/components/step-logs.tsx
+++ b/components/step-logs.tsx
@@ -1,106 +1,12 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger
-} from "@/components/ui/collapsible";
+import { StepLogItem } from "@/components/step-log-item";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { StepLogEntry } from "@/types";
-import {
-  AlertTriangle,
-  Bug,
-  ChevronRight,
-  Info,
-  Terminal,
-  XCircle
-} from "lucide-react";
-import { useState } from "react";
+import { Terminal } from "lucide-react";
 
 interface StepLogsProps {
   logs: StepLogEntry[] | undefined;
-}
-
-function StepLogItem({ log }: { log: StepLogEntry }) {
-  const [open, setOpen] = useState(false);
-
-  const getLevelIcon = (level?: string) => {
-    switch (level) {
-      case "warn":
-        return <AlertTriangle className="h-4 w-4 text-amber-500" />;
-      case "error":
-        return <XCircle className="h-4 w-4 text-red-500" />;
-      case "debug":
-        return <Bug className="h-4 w-4 text-purple-500" />;
-      default:
-        return <Info className="h-4 w-4 text-blue-500" />;
-    }
-  };
-
-  const getLevelBadgeClasses = (level?: string) => {
-    switch (level) {
-      case "warn":
-        return "bg-amber-50 text-amber-700 border-amber-200";
-      case "error":
-        return "bg-red-50 text-red-700 border-red-200";
-      case "debug":
-        return "bg-purple-50 text-purple-700 border-purple-200";
-      default:
-        return "bg-blue-50 text-blue-700 border-blue-200";
-    }
-  };
-
-  const getLevelText = (level?: string) => {
-    return (level || "info").toUpperCase();
-  };
-
-  return (
-    <Collapsible
-      open={open}
-      onOpenChange={setOpen}
-      className="p-3 rounded-md border bg-white border-slate-200">
-      <CollapsibleTrigger asChild>
-        <div className="flex items-start gap-3 cursor-pointer">
-          <div
-            className={`p-1.5 rounded ${getLevelBadgeClasses(log.level)
-              .split(" ")[0]
-              .replace("bg-", "bg-opacity-20")}`}>
-            {getLevelIcon(log.level)}
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1 flex-wrap">
-              <Badge
-                variant="outline"
-                className={`${getLevelBadgeClasses(log.level)} font-semibold`}>
-                {getLevelText(log.level)}
-              </Badge>
-              <span className="text-xs text-slate-500 font-mono bg-slate-100 px-1.5 py-0.5 rounded border border-slate-200">
-                {new Date(log.timestamp).toLocaleTimeString()}
-              </span>
-              {log.data !== null && (
-                <ChevronRight
-                  className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`}
-                />
-              )}
-            </div>
-            <p className="text-sm text-slate-800 leading-relaxed break-words">
-              {log.message}
-            </p>
-          </div>
-        </div>
-      </CollapsibleTrigger>
-      {log.data !== null && (
-        <CollapsibleContent className="mt-2 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-          <div className="bg-slate-800 text-slate-100 rounded p-2.5 border border-slate-700 max-h-60 overflow-y-auto">
-            <pre className="text-xs font-mono whitespace-pre-wrap">
-              {JSON.stringify(log.data, null, 2)}
-            </pre>
-          </div>
-        </CollapsibleContent>
-      )}
-    </Collapsible>
-  );
 }
 
 export function StepLogs({ logs }: StepLogsProps) {

--- a/lib/utils/url.ts
+++ b/lib/utils/url.ts
@@ -1,0 +1,16 @@
+import { API_PREFIXES } from "@/constants";
+
+export function extractPath(url: string): string {
+  const { GOOGLE_ADMIN, GOOGLE_CLOUD_IDENTITY, MS_GRAPH } = API_PREFIXES;
+
+  if (url.startsWith(GOOGLE_ADMIN)) {
+    return url.slice(GOOGLE_ADMIN.length);
+  }
+  if (url.startsWith(GOOGLE_CLOUD_IDENTITY)) {
+    return "/cloudidentity" + url.slice(GOOGLE_CLOUD_IDENTITY.length);
+  }
+  if (url.startsWith(MS_GRAPH)) {
+    return "/graph" + url.slice(MS_GRAPH.length);
+  }
+  return url;
+}

--- a/lib/workflow/fetch-utils.ts
+++ b/lib/workflow/fetch-utils.ts
@@ -34,7 +34,9 @@ export function createAuthenticatedFetch(
 
       context.addLog({
         timestamp: Date.now(),
-        message: `Request ${method} ${pageUrl}`,
+        message: `Request`,
+        method,
+        url: pageUrl,
         data: {
           url: pageUrl,
           method,
@@ -63,7 +65,10 @@ export function createAuthenticatedFetch(
 
       context.addLog({
         timestamp: Date.now(),
-        message: `Response ${res.status} ${pageUrl}`,
+        message: `Response`,
+        method,
+        status: res.status,
+        url: pageUrl,
         data: logData,
         level: LogLevel.Debug
       });

--- a/types.ts
+++ b/types.ts
@@ -12,6 +12,9 @@ export interface StepLogEntry {
   message: string;
   data?: unknown;
   level?: LogLevel;
+  method?: string;
+  status?: number;
+  url?: string;
 }
 
 export enum LogLevel {


### PR DESCRIPTION
## Summary
- add `extractPath` util for URL trimming
- add new StepLogItem component for compact HTTP logs
- simplify StepLogs to use StepLogItem
- show HTTP request/response details in fetch-utils
- update StepApiCalls to use shared `extractPath` and API_PREFIXES
- extend StepLogEntry with HTTP metadata fields

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855a89324ec83229e78bbb07fd4a2cf