### PR TITLE
Fix inbound SSO assignment API

### DIFF
--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -59,7 +59,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
         const profileId = vars.require(Var.SamlProfileId);
 
         const { inboundSsoAssignments = [] } = await google.get(
-          `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
+          ApiEndpoint.Google.SsoAssignments,
           AssignSchema,
           { flatten: "inboundSsoAssignments" }
         );
@@ -136,7 +136,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
        * { "error": { "code": 409, "message": "Assignment exists" } }
        */
       const op = await google.post(
-        `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
+        ApiEndpoint.Google.SsoAssignments,
         OpSchema,
         {
           targetGroup: `groups/${GroupId.AllUsers}`,
@@ -190,7 +190,7 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
       });
 
       const { inboundSsoAssignments = [] } = await google.get(
-        `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
+        ApiEndpoint.Google.SsoAssignments,
         AssignSchema,
         { flatten: "inboundSsoAssignments" }
       );


### PR DESCRIPTION
## Summary
- stop sending the `customer` query string when listing or creating inbound SSO assignments

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855aee274588322bf6483d7e4f0bf53