### PR TITLE
Add deep links to info modals

### DIFF
--- a/components/info-button.tsx
+++ b/components/info-button.tsx
@@ -30,7 +30,7 @@ import {
   PaginationPrevious
 } from "@/components/ui/pagination";
 import { Info, Loader2, Lock, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 
 export interface InfoItem {
   id: string;
@@ -49,12 +49,14 @@ interface InfoButtonProps {
   title: string;
   fetchItems: () => Promise<InfoItem[]>;
   deleteItems?: (ids: string[]) => Promise<DeleteResult>;
+  context?: ReactNode;
 }
 
 export function InfoButton({
   title,
   fetchItems,
-  deleteItems
+  deleteItems,
+  context
 }: InfoButtonProps) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -216,6 +218,7 @@ export function InfoButton({
       <DialogContent className="max-w-2xl max-h-[600px] flex flex-col">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
+          {context && <p className="text-xs text-slate-600 mt-1">{context}</p>}
         </DialogHeader>
 
         {deleteItems && deletableItems.length > 0 && (

--- a/components/info-buttons.tsx
+++ b/components/info-buttons.tsx
@@ -27,6 +27,7 @@ interface InfoButtonConfig {
   title: string;
   fetchItems: () => Promise<InfoItem[]>;
   deleteItems?: (ids: string[]) => Promise<DeleteResult>;
+  context?: React.ReactNode;
 }
 
 export function createInfoButton(config: InfoButtonConfig): React.FC {
@@ -36,6 +37,7 @@ export function createInfoButton(config: InfoButtonConfig): React.FC {
         title={config.title}
         fetchItems={config.fetchItems}
         deleteItems={config.deleteItems}
+        context={config.context}
       />
     );
   };
@@ -44,19 +46,46 @@ export function createInfoButton(config: InfoButtonConfig): React.FC {
 export const OuInfoButton = createInfoButton({
   title: "Existing Organizational Units",
   fetchItems: listOrgUnits,
-  deleteItems: env.ALLOW_INFO_PURGE ? deleteOrgUnits : undefined
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteOrgUnits : undefined,
+  context: (
+    <a
+      href="https://admin.google.com/ac/orgunits"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Google Admin
+    </a>
+  )
 });
 
 export const SamlInfoButton = createInfoButton({
   title: "Existing SAML Profiles",
   fetchItems: listSamlProfiles,
-  deleteItems: env.ALLOW_INFO_PURGE ? deleteSamlProfiles : undefined
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteSamlProfiles : undefined,
+  context: (
+    <a
+      href="https://admin.google.com/ac/apps/saml"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Google Admin
+    </a>
+  )
 });
 
 export const SsoInfoButton = createInfoButton({
   title: "Existing SSO Assignments",
   fetchItems: listSsoAssignments,
-  deleteItems: env.ALLOW_INFO_PURGE ? deleteSsoAssignments : undefined
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteSsoAssignments : undefined,
+  context: (
+    <a
+      href="https://admin.google.com/ac/security/inboundsso"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Google Admin
+    </a>
+  )
 });
 
 export const AppsInfoButton = createInfoButton({
@@ -68,17 +97,44 @@ export const AppsInfoButton = createInfoButton({
       deletable: !PROTECTED_RESOURCES.microsoftAppIds.has(item.id)
     }));
   },
-  deleteItems: env.ALLOW_INFO_PURGE ? deleteEnterpriseApps : undefined
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteEnterpriseApps : undefined,
+  context: (
+    <a
+      href="https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Microsoft Entra
+    </a>
+  )
 });
 
 export const ProvisioningInfoButton = createInfoButton({
   title: "Existing Provisioning Jobs",
   fetchItems: listProvisioningJobs,
-  deleteItems: env.ALLOW_INFO_PURGE ? deleteProvisioningJobs : undefined
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteProvisioningJobs : undefined,
+  context: (
+    <a
+      href="https://entra.microsoft.com/#view/Microsoft_AAD_Connect/ProvisioningMenuBlade"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Microsoft Entra
+    </a>
+  )
 });
 
 export const ClaimsInfoButton = createInfoButton({
   title: "Existing Claims Policies",
   fetchItems: listClaimsPolicies,
-  deleteItems: env.ALLOW_INFO_PURGE ? deleteClaimsPolicies : undefined
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteClaimsPolicies : undefined,
+  context: (
+    <a
+      href="https://entra.microsoft.com/#view/Microsoft_AAD_IAM/PoliciesMenuBlade/~/ClaimsMapping"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Microsoft Entra
+    </a>
+  )
 });

--- a/lib/info.ts
+++ b/lib/info.ts
@@ -188,6 +188,7 @@ export async function listClaimsPolicies(): Promise<InfoItem[]> {
   return data.value.map((p) => ({
     id: p.id,
     label: p.displayName ?? p.id,
+    href: `https://entra.microsoft.com/#view/Microsoft_AAD_IAM/PoliciesMenuBlade/~/ClaimsMappingPolicies/objectId/${p.id}`,
     deletable: true,
     deleteEndpoint: `${ApiEndpoint.Microsoft.ClaimsPolicies}/${p.id}`
   }));
@@ -215,6 +216,8 @@ export async function listEnterpriseApps(): Promise<InfoItem[]> {
   return data.value.map((a) => ({
     id: a.id,
     label: a.displayName,
+    subLabel: a.appId,
+    href: `https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/objectId/${a.id}`,
     deletable: !PROTECTED_RESOURCES.microsoftAppIds.has(a.appId),
     deleteEndpoint: `${ApiEndpoint.Microsoft.Applications}/${a.id}`
   }));

--- a/test/info/info.test.ts
+++ b/test/info/info.test.ts
@@ -158,7 +158,7 @@ describe("info server actions", () => {
       {
         id: "policy123",
         label: "Google Workspace Claims",
-        href: undefined,
+        href: "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/PoliciesMenuBlade/~/ClaimsMappingPolicies/objectId/policy123",
         deletable: true,
         deleteEndpoint:
           "https://graph.microsoft.com/beta/policies/claimsMappingPolicies/policy123"
@@ -178,7 +178,8 @@ describe("info server actions", () => {
       {
         id: "app1",
         label: "Google Workspace Provisioning",
-        href: undefined,
+        subLabel: "abcd1234",
+        href: "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/objectId/app1",
         deletable: true,
         deleteEndpoint: "https://graph.microsoft.com/beta/applications/app1"
       }


### PR DESCRIPTION
## Summary
- extend `InfoButton` to accept context
- add context links to info modals
- include deep links for claims policies and enterprise apps
- adjust tests for new links

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855aecd989c8322ab0adcf2c7ff06c8