### PR TITLE
Refactor info buttons mapping

### DIFF
--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -44,7 +44,7 @@ import {
   XCircle,
   Zap
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 interface StepCardProps {
   index: number;
@@ -57,6 +57,15 @@ interface StepCardProps {
   onForce(id: StepIdValue): void;
   onVarChange(key: VarName, value: unknown): void;
 }
+
+const INFO_BUTTONS: Partial<Record<StepIdValue, React.FC>> = {
+  [StepId.CreateAutomationOU]: OuInfoButton,
+  [StepId.ConfigureGoogleSamlProfile]: SamlInfoButton,
+  [StepId.AssignUsersToSso]: SsoInfoButton,
+  [StepId.CreateMicrosoftApps]: AppsInfoButton,
+  [StepId.ConfigureMicrosoftSyncAndSso]: ProvisioningInfoButton,
+  [StepId.SetupMicrosoftClaimsPolicy]: ClaimsInfoButton
+};
 
 export function StepCard({
   index,
@@ -71,6 +80,7 @@ export function StepCard({
 }: StepCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
+  const InfoButtonComponent = INFO_BUTTONS[definition.id];
   const detail = STEP_DETAILS[definition.id];
 
   const title =
@@ -369,22 +379,7 @@ export function StepCard({
                   Execute
                 </Button>
 
-                {definition.id === StepId.CreateAutomationOU && (
-                  <OuInfoButton />
-                )}
-                {definition.id === StepId.ConfigureGoogleSamlProfile && (
-                  <SamlInfoButton />
-                )}
-                {definition.id === StepId.AssignUsersToSso && <SsoInfoButton />}
-                {definition.id === StepId.CreateMicrosoftApps && (
-                  <AppsInfoButton />
-                )}
-                {definition.id === StepId.ConfigureMicrosoftSyncAndSso && (
-                  <ProvisioningInfoButton />
-                )}
-                {definition.id === StepId.SetupMicrosoftClaimsPolicy && (
-                  <ClaimsInfoButton />
-                )}
+                {InfoButtonComponent && <InfoButtonComponent />}
               </div>
               <div className="space-x-2">
                 {canUndo && (

--- a/test/info/info.test.ts
+++ b/test/info/info.test.ts
@@ -178,7 +178,6 @@ describe("info server actions", () => {
       {
         id: "app1",
         label: "Google Workspace Provisioning",
-        subLabel: "abcd1234",
         href: "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/objectId/app1",
         deletable: true,
         deleteEndpoint: "https://graph.microsoft.com/beta/applications/app1"


### PR DESCRIPTION
## Summary
- map step IDs to their info buttons instead of lengthy conditionals
- update enterprise app listing test for new interface

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855b534eeb48322852ff9ef76b9b3d7