### PR TITLE
Disable execute button after completion

### DIFF
--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -363,7 +363,9 @@ export function StepCard({
                     e.stopPropagation();
                     onExecute(definition.id);
                   }}
-                  disabled={!canExecute || executing}
+                  disabled={
+                    !canExecute || executing || state?.status === "complete"
+                  }
                   variant="default">
                   <Play className="h-3.5 w-3.5 mr-1.5" />
                   Execute


### PR DESCRIPTION
## Summary
- disable the Execute button when a step is already complete

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855b56a689c8322b03c99ef80f39d84