### PR TITLE
Refactor provisioning and SSO steps

### DIFF
--- a/components/step-api-calls.tsx
+++ b/components/step-api-calls.tsx
@@ -225,7 +225,7 @@ export const stepApiMetadata: Record<StepIdValue, ApiCallMetadata[]> = {
     }
   ],
 
-  "configure-microsoft-sync-and-sso": [
+  "setup-microsoft-provisioning": [
     {
       method: "GET",
       endpoint:
@@ -250,6 +250,35 @@ export const stepApiMetadata: Record<StepIdValue, ApiCallMetadata[]> = {
       endpoint:
         "/graph/v1.0/servicePrincipals/{provisioningServicePrincipalId}/synchronization/jobs/{jobId}/start",
       description: "Start synchronization"
+    }
+  ],
+
+  "configure-microsoft-sso": [
+    {
+      method: "PATCH",
+      endpoint: "/graph/v1.0/servicePrincipals/{ssoServicePrincipalId}",
+      description: "Set SSO mode to saml"
+    },
+    {
+      method: "GET",
+      endpoint: extractPath(ApiEndpoint.Microsoft.Organization),
+      description: "Get tenant information"
+    },
+    {
+      method: "PATCH",
+      endpoint: "/graph/v1.0/servicePrincipals/{ssoServicePrincipalId}",
+      description: "Configure SAML URLs"
+    },
+    {
+      method: "PATCH",
+      endpoint: "/graph/beta/applications/{applicationObjectId}",
+      description: "Set identifier URIs and redirect URIs"
+    },
+    {
+      method: "POST",
+      endpoint:
+        "/graph/beta/servicePrincipals/{ssoServicePrincipalId}/addTokenSigningCertificate",
+      description: "Create signing certificate"
     }
   ],
 

--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -63,7 +63,8 @@ const INFO_BUTTONS: Partial<Record<StepIdValue, React.FC>> = {
   [StepId.ConfigureGoogleSamlProfile]: SamlInfoButton,
   [StepId.AssignUsersToSso]: SsoInfoButton,
   [StepId.CreateMicrosoftApps]: AppsInfoButton,
-  [StepId.ConfigureMicrosoftSyncAndSso]: ProvisioningInfoButton,
+  [StepId.SetupMicrosoftProvisioning]: ProvisioningInfoButton,
+  [StepId.ConfigureMicrosoftSso]: ProvisioningInfoButton,
   [StepId.SetupMicrosoftClaimsPolicy]: ClaimsInfoButton
 };
 

--- a/constants.ts
+++ b/constants.ts
@@ -64,6 +64,9 @@ export const ApiEndpoint = {
     TokenSigningCertificates: (spId: string) =>
       `https://graph.microsoft.com/beta/servicePrincipals/${spId}/tokenSigningCertificates`,
 
+    AddTokenSigningCertificate: (spId: string) =>
+      `https://graph.microsoft.com/beta/servicePrincipals/${spId}/addTokenSigningCertificate`,
+
     Organization: "https://graph.microsoft.com/v1.0/organization",
 
     Me: "https://graph.microsoft.com/v1.0/me"

--- a/lib/workflow/step-details.ts
+++ b/lib/workflow/step-details.ts
@@ -34,10 +34,15 @@ export const STEP_DETAILS: Record<string, StepDetail> = {
     description:
       "Instantiates the Google Workspace provisioning and SSO applications in Microsoft Entra. Corresponding service principals are created automatically."
   },
-  "configure-microsoft-sync-and-sso": {
-    title: "Configure Microsoft Sync and SSO",
+  "setup-microsoft-provisioning": {
+    title: "Setup Microsoft Provisioning",
     description:
-      "Sets up Azure AD provisioning and single sign‑on. Credentials are stored and an initial synchronization job is started."
+      "Configures Azure AD user provisioning to Google Workspace. Creates a synchronization job, sets credentials, and starts the initial sync."
+  },
+  "configure-microsoft-sso": {
+    title: "Configure Microsoft SSO",
+    description:
+      "Configures SAML single sign-on settings in Microsoft Entra. Sets SSO mode, configures SAML URLs, updates application settings, and generates signing certificates."
   },
   "setup-microsoft-claims-policy": {
     title: "Setup Microsoft Claims Policy",

--- a/lib/workflow/step-ids.ts
+++ b/lib/workflow/step-ids.ts
@@ -9,7 +9,8 @@ export const StepId = {
   CreateAdminRoleAndAssignUser: "create-admin-role-and-assign-user",
   ConfigureGoogleSamlProfile: "configure-google-saml-profile",
   CreateMicrosoftApps: "create-microsoft-apps",
-  ConfigureMicrosoftSyncAndSso: "configure-microsoft-sync-and-sso",
+  SetupMicrosoftProvisioning: "setup-microsoft-provisioning",
+  ConfigureMicrosoftSso: "configure-microsoft-sso",
   SetupMicrosoftClaimsPolicy: "setup-microsoft-claims-policy",
   CompleteGoogleSsoSetup: "complete-google-sso-setup",
   AssignUsersToSso: "assign-users-to-sso"

--- a/lib/workflow/step-registry.ts
+++ b/lib/workflow/step-registry.ts
@@ -10,12 +10,13 @@ import { StepIdValue } from "@/types";
 import assignUsersToSso from "./steps/assign-users-to-sso";
 import completeGoogleSsoSetup from "./steps/complete-google-sso-setup";
 import configureGoogleSamlProfile from "./steps/configure-google-saml-profile";
-import configureMicrosoftSyncAndSso from "./steps/configure-microsoft-sync-and-sso";
+import configureMicrosoftSso from "./steps/configure-microsoft-sso";
 import createAdminRoleAndAssignUser from "./steps/create-admin-role-and-assign-user";
 import createAutomationOu from "./steps/create-automation-ou";
 import createMicrosoftApps from "./steps/create-microsoft-apps";
 import createServiceUser from "./steps/create-service-user";
 import setupMicrosoftClaimsPolicy from "./steps/setup-microsoft-claims-policy";
+import setupMicrosoftProvisioning from "./steps/setup-microsoft-provisioning";
 import verifyPrimaryDomain from "./steps/verify-primary-domain";
 
 const allSteps = [
@@ -25,7 +26,8 @@ const allSteps = [
   createAdminRoleAndAssignUser,
   configureGoogleSamlProfile,
   createMicrosoftApps,
-  configureMicrosoftSyncAndSso,
+  setupMicrosoftProvisioning,
+  configureMicrosoftSso,
   setupMicrosoftClaimsPolicy,
   completeGoogleSsoSetup,
   assignUsersToSso

--- a/lib/workflow/steps/AGENTS.md
+++ b/lib/workflow/steps/AGENTS.md
@@ -601,81 +601,32 @@ ssoServicePrincipalId = .servicePrincipal.id
 ssoAppId = .application.appId
 ```
 
-## Step 7: `configureMicrosoftSyncAndSso`
+## Step 7: `setupMicrosoftProvisioning`
 
 ### Step 7 Purpose
 
-Configure Azure AD provisioning and SSO settings.
-
-### Step 7 State Check
-
-#### Step 7 Check Request
-
-```http
-GET https://graph.microsoft.com/v1.0/servicePrincipals/{provisioningServicePrincipalId}/synchronization/jobs
-Authorization: Bearer {msGraphToken}
-```
-
-#### Step 7 Success Response (`200 OK`)
-
-```json
-{ "value": [ { "status": { "code": "Active" } }, ... ] }
-```
-
-#### Step 7 Completion Criteria
-
-At least one `value[].status.code != "Paused"`
+Configure Azure AD provisioning to sync users to Google Workspace.
 
 ### Step 7 Execution
 
-#### Step 7 Prerequisites
+1. Get sync template ID
+2. Create synchronization job
+3. Set credentials (BaseAddress and SecretToken)
+4. Start synchronization
 
-- `msGraphToken`
-- `provisioningServicePrincipalId`, `generatedPassword`
+## Step 8: `configureMicrosoftSso`
 
-#### Step 7 Execution Requests
+### Step 8 Purpose
 
-1. Create Job
+Configure Microsoft SAML SSO settings and generate signing certificate.
 
-```http
-POST https://graph.microsoft.com/v1.0/servicePrincipals/{provisioningServicePrincipalId}/synchronization/jobs
-Authorization: Bearer {msGraphToken}
-Content-Type: application/json
+### Step 8 Execution
 
-{ "templateId": "gsuite" }
-```
-
-Lookup the template ID via `GET /servicePrincipals/{provisioningServicePrincipalId}/synchronization/templates` and match on `factoryTag` `gsuite`.
-
-Expected: `201 Created` returning job ID
-
-1. Set Secrets
-
-```http
-PUT https://graph.microsoft.com/v1.0/servicePrincipals/{provisioningServicePrincipalId}/synchronization/secrets
-Authorization: Bearer {msGraphToken}
-Content-Type: application/json
-
-{
-  "value": [
-    { "key": "BaseAddress", "value": "https://admin.googleapis.com/admin/directory/v1" },
-    { "key": "SecretToken", "value": "{generatedPassword}" }
-  ]
-}
-```
-
-Expected: `204 No Content`
-
-1. Start Job
-
-```http
-POST https://graph.microsoft.com/v1.0/servicePrincipals/{provisioningServicePrincipalId}/synchronization/jobs/{jobId}/start
-Authorization: Bearer {msGraphToken}
-```
-
-Expected: `204 No Content`
-
-## Step 8: `setupMicrosoftClaimsPolicy`
+1. Set preferredSingleSignOnMode to "saml" on service principal
+2. Configure SAML URLs on service principal
+3. Set identifierUris and redirectUris on application object
+4. Generate token signing certificate
+5. Extract certificate and SSO URLs for Google configuration
 
 ### Step 8 Purpose
 

--- a/lib/workflow/steps/configure-microsoft-sso.ts
+++ b/lib/workflow/steps/configure-microsoft-sso.ts
@@ -1,0 +1,238 @@
+import { ApiEndpoint } from "@/constants";
+import { EmptyResponseSchema } from "@/lib/workflow/utils";
+import { LogLevel, StepId, Var } from "@/types";
+import { z } from "zod";
+import { defineStep } from "../step-builder";
+
+export default defineStep(StepId.ConfigureMicrosoftSso)
+  .requires(
+    Var.MsGraphToken,
+    Var.SsoServicePrincipalId,
+    Var.SsoAppId,
+    Var.EntityId,
+    Var.AcsUrl
+  )
+  .provides(Var.MsSigningCertificate, Var.MsSsoLoginUrl, Var.MsSsoEntityId)
+  /**
+   * GET https://graph.microsoft.com/v1.0/servicePrincipals/{ssoServicePrincipalId}?$select=preferredSingleSignOnMode,samlSingleSignOnSettings
+   * Headers: { Authorization: Bearer {msGraphToken} }
+   *
+   * Success response (200)
+   * { "preferredSingleSignOnMode": "saml", "samlSingleSignOnSettings": { "loginUrl": "https://login.microsoftonline.com/..." } }
+   *
+   * GET https://graph.microsoft.com/beta/servicePrincipals/{ssoServicePrincipalId}/tokenSigningCertificates
+   * Headers: { Authorization: Bearer {msGraphToken} }
+   *
+   * Success response (200)
+   * { "value": [ { "keyId": "...", "key": "MII...", "startDateTime": "2024-01-01T00:00:00Z", "endDateTime": "2025-01-01T00:00:00Z" } ] }
+   */
+
+  .check(
+    async ({
+      vars,
+      microsoft,
+      markComplete,
+      markIncomplete,
+      markCheckFailed,
+      log
+    }) => {
+      try {
+        const spId = vars.require(Var.SsoServicePrincipalId);
+
+        const SpSchema = z.object({
+          preferredSingleSignOnMode: z.string().nullable(),
+          samlSingleSignOnSettings: z
+            .object({ loginUrl: z.string().nullable() })
+            .nullable()
+        });
+
+        const sp = await microsoft.get(
+          `${ApiEndpoint.Microsoft.ServicePrincipals}/${spId}?$select=preferredSingleSignOnMode,samlSingleSignOnSettings`,
+          SpSchema
+        );
+
+        if (
+          sp.preferredSingleSignOnMode === "saml"
+          && sp.samlSingleSignOnSettings?.loginUrl
+        ) {
+          log(LogLevel.Info, "Microsoft SSO already configured");
+
+          // Need to fetch certificate to pass to Google
+          const CertSchema = z.object({
+            value: z.array(
+              z.object({
+                keyId: z.string(),
+                startDateTime: z.string(),
+                endDateTime: z.string(),
+                key: z.string().nullable()
+              })
+            )
+          });
+
+          const certs = await microsoft.get(
+            ApiEndpoint.Microsoft.TokenSigningCertificates(spId),
+            CertSchema
+          );
+
+          const now = new Date();
+          const activeCert = certs.value.find((cert) => {
+            const start = new Date(cert.startDateTime);
+            const end = new Date(cert.endDateTime);
+            return start <= now && now <= end && cert.key;
+          });
+
+          if (activeCert?.key) {
+            const TenantSchema = z.object({
+              value: z.array(z.object({ id: z.string() }))
+            });
+            const tenantInfo = await microsoft.get(
+              ApiEndpoint.Microsoft.Organization,
+              TenantSchema
+            );
+            const tenantId = tenantInfo.value[0]?.id;
+
+            markComplete({
+              msSigningCertificate: activeCert.key,
+              msSsoLoginUrl: sp.samlSingleSignOnSettings.loginUrl!,
+              msSsoEntityId: `https://sts.windows.net/${tenantId}/`
+            });
+          } else {
+            markIncomplete("SSO configured but certificate missing", {});
+          }
+        } else {
+          markIncomplete("Microsoft SSO not configured", {});
+        }
+      } catch (error) {
+        log(LogLevel.Error, "Failed to check SSO configuration", { error });
+        markCheckFailed(
+          error instanceof Error ? error.message : "Check failed"
+        );
+      }
+    }
+    /**
+     * PATCH https://graph.microsoft.com/v1.0/servicePrincipals/{ssoServicePrincipalId}
+     * Body: { preferredSingleSignOnMode: "saml" }
+     *
+     * GET https://graph.microsoft.com/v1.0/organization
+     *
+     * PATCH https://graph.microsoft.com/v1.0/servicePrincipals/{ssoServicePrincipalId}
+     * Body: { samlSingleSignOnSettings: { loginUrl, logoutUrl, relayState: "" } }
+     *
+     * GET https://graph.microsoft.com/v1.0/applications?$filter=appId eq {ssoAppId}
+     *
+     * PATCH https://graph.microsoft.com/v1.0/applications/{applicationObjectId}
+     * Body: { identifierUris: [entityId], web: { redirectUris: [acsUrl] } }
+     *
+     * POST https://graph.microsoft.com/beta/servicePrincipals/{ssoServicePrincipalId}/addTokenSigningCertificate
+     * Body: { displayName: "CN=Google Workspace SSO", endDateTime: "{iso}" }
+     * Success response (201) { "key": "MII..." }
+     */
+  )
+  .execute(async ({ vars, microsoft, output, markFailed, log }) => {
+    try {
+      const spId = vars.require(Var.SsoServicePrincipalId);
+      const appId = vars.require(Var.SsoAppId);
+      const entityId = vars.require(Var.EntityId);
+      const acsUrl = vars.require(Var.AcsUrl);
+
+      log(LogLevel.Info, "Setting SSO mode to SAML");
+
+      // 1. Set preferred SSO mode on service principal
+      await microsoft.patch(
+        `${ApiEndpoint.Microsoft.ServicePrincipals}/${spId}`,
+        EmptyResponseSchema,
+        { preferredSingleSignOnMode: "saml" }
+      );
+
+      // 2. Get tenant ID for URLs
+      const TenantSchema = z.object({
+        value: z.array(z.object({ id: z.string() }))
+      });
+      const tenantInfo = await microsoft.get(
+        ApiEndpoint.Microsoft.Organization,
+        TenantSchema
+      );
+      const tenantId = tenantInfo.value[0]?.id;
+      if (!tenantId) {
+        throw new Error("Unable to determine Microsoft tenant ID");
+      }
+
+      const loginUrl = `https://login.microsoftonline.com/${tenantId}/saml2`;
+      const msSsoEntityId = `https://sts.windows.net/${tenantId}/`;
+
+      // 3. Configure SAML settings on service principal
+      await microsoft.patch(
+        `${ApiEndpoint.Microsoft.ServicePrincipals}/${spId}`,
+        EmptyResponseSchema,
+        {
+          samlSingleSignOnSettings: {
+            loginUrl: loginUrl,
+            logoutUrl: loginUrl,
+            relayState: ""
+          }
+        }
+      );
+
+      // 4. Get the application object ID (different from appId)
+      const AppFilterSchema = z.object({
+        value: z.array(z.object({ id: z.string() }))
+      });
+      const apps = await microsoft.get(
+        `${ApiEndpoint.Microsoft.Applications}?$filter=appId eq '${appId}'`,
+        AppFilterSchema
+      );
+      const applicationObjectId = apps.value[0]?.id;
+      if (!applicationObjectId) {
+        throw new Error("Unable to find application object");
+      }
+
+      // 5. Set identifier URIs and reply URLs on APPLICATION object
+      log(LogLevel.Info, "Configuring application URLs");
+      await microsoft.patch(
+        `${ApiEndpoint.Microsoft.Applications}/${applicationObjectId}`,
+        EmptyResponseSchema,
+        { identifierUris: [entityId], web: { redirectUris: [acsUrl] } }
+      );
+
+      // 6. Create signing certificate
+      log(LogLevel.Info, "Creating SAML signing certificate");
+      const CertSchema = z.object({
+        keyId: z.string(),
+        type: z.string(),
+        usage: z.string(),
+        key: z.string().nullable()
+      });
+
+      const certResponse = await microsoft.post(
+        ApiEndpoint.Microsoft.AddTokenSigningCertificate(spId),
+        CertSchema,
+        {
+          displayName: "CN=Google Workspace SSO",
+          endDateTime: new Date(
+            Date.now() + 365 * 24 * 60 * 60 * 1000
+          ).toISOString()
+        }
+      );
+
+      if (!certResponse.key) {
+        throw new Error("Failed to generate signing certificate");
+      }
+
+      log(LogLevel.Info, "Microsoft SSO configuration completed");
+      output({
+        msSigningCertificate: certResponse.key,
+        msSsoLoginUrl: loginUrl,
+        msSsoEntityId: msSsoEntityId
+      });
+    } catch (error) {
+      log(LogLevel.Error, "Failed to configure Microsoft SSO", { error });
+      markFailed(error instanceof Error ? error.message : "Execute failed");
+    }
+  })
+  /**
+   * No remote changes are reverted for this step
+   */
+  .undo(async ({ markReverted }) => {
+    markReverted();
+  })
+  .build();

--- a/lib/workflow/variables.ts
+++ b/lib/workflow/variables.ts
@@ -34,9 +34,9 @@ export const WORKFLOW_VARIABLES: Record<string, VariableMetadata> = {
     sensitive: true,
     consumedBy: [
       StepId.CreateMicrosoftApps,
-      StepId.ConfigureMicrosoftSyncAndSso,
-      StepId.SetupMicrosoftClaimsPolicy,
-      StepId.CompleteGoogleSsoSetup
+      StepId.SetupMicrosoftProvisioning,
+      StepId.ConfigureMicrosoftSso,
+      StepId.SetupMicrosoftClaimsPolicy
     ]
   },
   primaryDomain: {
@@ -139,7 +139,7 @@ export const WORKFLOW_VARIABLES: Record<string, VariableMetadata> = {
     category: "state",
     description: "Password for provisioning account",
     producedBy: StepId.CreateServiceUser,
-    consumedBy: [StepId.ConfigureMicrosoftSyncAndSso],
+    consumedBy: [StepId.SetupMicrosoftProvisioning],
     sensitive: true
   },
   adminRoleId: {
@@ -160,8 +160,8 @@ export const WORKFLOW_VARIABLES: Record<string, VariableMetadata> = {
     description: "Service principal for SSO app",
     producedBy: StepId.CreateMicrosoftApps,
     consumedBy: [
-      StepId.SetupMicrosoftClaimsPolicy,
-      StepId.CompleteGoogleSsoSetup
+      StepId.ConfigureMicrosoftSso,
+      StepId.SetupMicrosoftClaimsPolicy
     ]
   },
   provisioningServicePrincipalId: {
@@ -169,13 +169,14 @@ export const WORKFLOW_VARIABLES: Record<string, VariableMetadata> = {
     category: "state",
     description: "Service principal for provisioning app",
     producedBy: StepId.CreateMicrosoftApps,
-    consumedBy: [StepId.ConfigureMicrosoftSyncAndSso]
+    consumedBy: [StepId.SetupMicrosoftProvisioning]
   },
   ssoAppId: {
     type: "string",
     category: "state",
     description: "Application ID for SSO app",
-    producedBy: StepId.CreateMicrosoftApps
+    producedBy: StepId.CreateMicrosoftApps,
+    consumedBy: [StepId.ConfigureMicrosoftSso]
   },
   samlProfileId: {
     type: "string",
@@ -188,19 +189,43 @@ export const WORKFLOW_VARIABLES: Record<string, VariableMetadata> = {
     type: "string",
     category: "state",
     description: "Service provider entityId",
-    producedBy: StepId.ConfigureGoogleSamlProfile
+    producedBy: StepId.ConfigureGoogleSamlProfile,
+    consumedBy: [StepId.ConfigureMicrosoftSso]
   },
   acsUrl: {
     type: "string",
     category: "state",
     description: "Assertion consumer service URL",
-    producedBy: StepId.ConfigureGoogleSamlProfile
+    producedBy: StepId.ConfigureGoogleSamlProfile,
+    consumedBy: [StepId.ConfigureMicrosoftSso]
   },
   claimsPolicyId: {
     type: "string",
     category: "state",
     description: "Claims policy identifier",
     producedBy: StepId.SetupMicrosoftClaimsPolicy
+  },
+  msSigningCertificate: {
+    type: "string",
+    category: "state",
+    description: "Microsoft SAML signing certificate in PEM format",
+    producedBy: StepId.ConfigureMicrosoftSso,
+    consumedBy: [StepId.CompleteGoogleSsoSetup],
+    sensitive: true
+  },
+  msSsoLoginUrl: {
+    type: "string",
+    category: "state",
+    description: "Microsoft SAML SSO login URL",
+    producedBy: StepId.ConfigureMicrosoftSso,
+    consumedBy: [StepId.CompleteGoogleSsoSetup]
+  },
+  msSsoEntityId: {
+    type: "string",
+    category: "state",
+    description: "Microsoft SAML entity ID",
+    producedBy: StepId.ConfigureMicrosoftSso,
+    consumedBy: [StepId.CompleteGoogleSsoSetup]
   }
 } as const satisfies Record<string, VariableMetadata>;
 

--- a/scripts/e2e-states.ts
+++ b/scripts/e2e-states.ts
@@ -60,7 +60,8 @@ export async function createPartiallyCompletedState(step: string) {
         orgUnitPath: "/"
       });
       break;
-    case "configure-microsoft-sync-and-sso":
+    case "setup-microsoft-provisioning":
+    case "configure-microsoft-sso":
       await createMicrosoftApp(TemplateId.GoogleWorkspaceConnector);
       await createMicrosoftApp(TemplateId.GoogleWorkspaceSaml);
       break;
@@ -131,7 +132,7 @@ async function createSsoAssignment(body: Record<string, unknown>) {
 
 export async function createErrorState(step: string) {
   switch (step) {
-    case "configure-microsoft-sync-and-sso": {
+    case "setup-microsoft-provisioning": {
       const spId = await getProvisioningServicePrincipalId();
       if (spId) {
         const templateId = await getSyncTemplateId(

--- a/test/e2e/workflow.test.ts
+++ b/test/e2e/workflow.test.ts
@@ -68,7 +68,8 @@ if (
       StepId.CreateAdminRoleAndAssignUser,
       StepId.ConfigureGoogleSamlProfile,
       StepId.CreateMicrosoftApps,
-      StepId.ConfigureMicrosoftSyncAndSso,
+      StepId.SetupMicrosoftProvisioning,
+      StepId.ConfigureMicrosoftSso,
       StepId.SetupMicrosoftClaimsPolicy,
       StepId.CompleteGoogleSsoSetup,
       StepId.AssignUsersToSso


### PR DESCRIPTION
## Summary
- split Microsoft provisioning and SSO configuration into separate steps
- store new SSO-related variables for Google integration
- add token signing certificate endpoint constant
- update workflow registry, step details, and docs
- adjust tests and scripts for new step IDs
- add inline API documentation comments in provisioning and SSO steps

## Testing
- `./scripts/token-info.sh`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855c010ae1c8322b08f3d7ec701ca69