### PR TITLE
Persist workflow state across sessions

### DIFF
--- a/components/provider-login.tsx
+++ b/components/provider-login.tsx
@@ -68,6 +68,9 @@ export function ProviderLogin({ onUpdate }: Props) {
     try {
       await fetch(`/api/auth/signout/${provider}`, { method: "POST" });
     } finally {
+      if (typeof window !== "undefined") {
+        localStorage.removeItem("workflowState");
+      }
       window.location.href = "/";
     }
   }, []);


### PR DESCRIPTION
## Summary
- store workflow vars and step status in localStorage
- clear stored state on sign out
- parse saved workflow state once and merge with defaults

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855cdf3667c83229b7274ed1879ae21