### PR TITLE
Fix SSO info fetch

### DIFF
--- a/lib/info.ts
+++ b/lib/info.ts
@@ -98,10 +98,9 @@ export async function listSsoAssignments(): Promise<InfoItem[]> {
       .optional()
   });
 
-  const res = await fetch(
-    `${ApiEndpoint.Google.SsoAssignments}?customer=customers/my_customer`,
-    { headers: { Authorization: `Bearer ${token.accessToken}` } }
-  );
+  const res = await fetch(ApiEndpoint.Google.SsoAssignments, {
+    headers: { Authorization: `Bearer ${token.accessToken}` }
+  });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = Schema.parse(await res.json());
   return (


### PR DESCRIPTION
## Summary
- fix Google SSO info fetch by removing invalid query parameter

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855dd17817c8322912af9bcdc5d8dbe