### PR TITLE
Fix info button placement

### DIFF
--- a/components/info-buttons.tsx
+++ b/components/info-buttons.tsx
@@ -4,17 +4,22 @@ import { InfoButton } from "@/components/info-button";
 import { PROTECTED_RESOURCES } from "@/constants";
 import { env } from "@/env";
 import {
+  listAdminRoles,
   listClaimsPolicies,
+  listDomains,
   listEnterpriseApps,
   listOrgUnits,
   listProvisioningJobs,
   listSamlProfiles,
   listSsoAssignments,
+  listUsers,
   type InfoItem
 } from "@/lib/info";
 import {
   deleteClaimsPolicies,
   deleteEnterpriseApps,
+  deleteGoogleRoles,
+  deleteGoogleUsers,
   deleteOrgUnits,
   deleteProvisioningJobs,
   deleteSamlProfiles,
@@ -65,6 +70,50 @@ export const SamlInfoButton = createInfoButton({
   context: (
     <a
       href="https://admin.google.com/ac/apps/saml"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Google Admin
+    </a>
+  )
+});
+
+export const DomainInfoButton = createInfoButton({
+  title: "Existing Domains",
+  fetchItems: listDomains,
+  context: (
+    <a
+      href="https://admin.google.com/ac/domains"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Google Admin
+    </a>
+  )
+});
+
+export const UsersInfoButton = createInfoButton({
+  title: "Existing Users",
+  fetchItems: listUsers,
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteGoogleUsers : undefined,
+  context: (
+    <a
+      href="https://admin.google.com/ac/users"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 hover:underline">
+      Open in Google Admin
+    </a>
+  )
+});
+
+export const RolesInfoButton = createInfoButton({
+  title: "Existing Admin Roles",
+  fetchItems: listAdminRoles,
+  deleteItems: env.ALLOW_INFO_PURGE ? deleteGoogleRoles : undefined,
+  context: (
+    <a
+      href="https://admin.google.com/ac/roles"
       target="_blank"
       rel="noopener noreferrer"
       className="text-blue-600 hover:underline">

--- a/components/step-card.tsx
+++ b/components/step-card.tsx
@@ -3,10 +3,13 @@
 import {
   AppsInfoButton,
   ClaimsInfoButton,
+  DomainInfoButton,
   OuInfoButton,
   ProvisioningInfoButton,
+  RolesInfoButton,
   SamlInfoButton,
-  SsoInfoButton
+  SsoInfoButton,
+  UsersInfoButton
 } from "@/components/info-buttons";
 import { StepApiCalls } from "@/components/step-api-calls";
 import { StepLogs } from "@/components/step-logs";
@@ -64,13 +67,17 @@ interface StepCardProps {
 }
 
 const INFO_BUTTONS: Partial<Record<StepIdValue, React.FC>> = {
+  [StepId.VerifyPrimaryDomain]: DomainInfoButton,
   [StepId.CreateAutomationOU]: OuInfoButton,
+  [StepId.CreateServiceUser]: UsersInfoButton,
+  [StepId.CreateAdminRoleAndAssignUser]: RolesInfoButton,
   [StepId.ConfigureGoogleSamlProfile]: SamlInfoButton,
-  [StepId.AssignUsersToSso]: SsoInfoButton,
   [StepId.CreateMicrosoftApps]: AppsInfoButton,
   [StepId.SetupMicrosoftProvisioning]: ProvisioningInfoButton,
-  [StepId.ConfigureMicrosoftSso]: ProvisioningInfoButton,
-  [StepId.SetupMicrosoftClaimsPolicy]: ClaimsInfoButton
+  [StepId.ConfigureMicrosoftSso]: AppsInfoButton,
+  [StepId.SetupMicrosoftClaimsPolicy]: ClaimsInfoButton,
+  [StepId.CompleteGoogleSsoSetup]: SamlInfoButton,
+  [StepId.AssignUsersToSso]: SsoInfoButton
 };
 
 export function StepCard({

--- a/lib/workflow/info-actions.ts
+++ b/lib/workflow/info-actions.ts
@@ -129,6 +129,13 @@ export async function deleteGoogleRoles(ids: string[]): Promise<DeleteResult> {
   )(ids);
 }
 
+export async function deleteGoogleUsers(ids: string[]): Promise<DeleteResult> {
+  return createGoogleDeleteAction(
+    (id) => `${ApiEndpoint.Google.Users}/${id}`,
+    "User"
+  )(ids);
+}
+
 export async function deleteClaimsPolicies(
   ids: string[]
 ): Promise<DeleteResult> {


### PR DESCRIPTION
## Summary
- add info dialogs for domains, users, and admin roles
- clean up workflow info actions
- map every workflow step to the correct info button

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855e07f1c448322a4bade8e33f2a6cd