### PR TITLE
Move header into root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable workflow/no-hardcoded-config */
 import { WorkflowProvider } from "@/components/workflow-context";
+import { WorkflowHeader } from "@/components/workflow-header";
 import { PROTECTED_RESOURCES } from "@/constants";
 import { env } from "@/env";
 import { getAllSteps } from "@/lib/workflow/step-registry";
@@ -39,7 +40,8 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <WorkflowProvider steps={allSteps} initialVars={DEFAULT_CONFIG}>
-          {children}
+          <WorkflowHeader />
+          <main className="flex h-[calc(100vh-64px)]">{children}</main>
         </WorkflowProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,15 @@
 import { StepsList } from "@/components/steps-list";
 import { VarsPanel } from "@/components/vars-panel";
-import { WorkflowHeader } from "@/components/workflow-header";
 
 export default function HomePage() {
   return (
     <>
-      <WorkflowHeader />
-      <main className="flex h-[calc(100vh-64px)]">
-        <section className="flex-1 overflow-y-auto bg-slate-50/30 p-6">
-          <StepsList />
-        </section>
-        <aside className="w-96 border-l bg-white overflow-y-auto">
-          <VarsPanel />
-        </aside>
-      </main>
+      <section className="flex-1 overflow-y-auto bg-slate-50/30 p-6">
+        <StepsList />
+      </section>
+      <aside className="w-96 border-l bg-white overflow-y-auto">
+        <VarsPanel />
+      </aside>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- share the workflow header via the app layout
- keep page content focused on step list and variables panel

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855e1d9d6008322b037c659c4c10cb3