### PR TITLE
Fix hydration mismatch from localStorage state

### DIFF
--- a/components/workflow-context.tsx
+++ b/components/workflow-context.tsx
@@ -78,16 +78,13 @@ export function WorkflowProvider({
     }
   }, []);
 
-  const stored = loadStoredState();
-
-  const [vars, setVarsState] = useState<Partial<WorkflowVars>>({
-    ...initialVars,
-    ...(stored?.vars ?? {})
-  });
+  const [vars, setVarsState] = useState<Partial<WorkflowVars>>(() => ({
+    ...initialVars
+  }));
 
   const [status, setStatus] = useState<
     Partial<Record<StepIdValue, StepUIState>>
-  >(stored?.status ?? {});
+  >({});
   const statusRef = useRef<Partial<Record<StepIdValue, StepUIState>>>(status);
   const [executing, setExecuting] = useState<StepIdValue | null>(null);
   const [sessionLoaded, setSessionLoaded] = useState(false);
@@ -95,6 +92,21 @@ export function WorkflowProvider({
   const listeners = useRef<Map<VarName, Set<(value: unknown) => void>>>(
     new Map()
   );
+
+  // Load stored workflow state on mount
+  useEffect(() => {
+    const stored = loadStoredState();
+    if (stored) {
+      if (stored.vars) {
+        setVarsState((prev) => ({ ...prev, ...stored.vars }));
+      }
+      if (stored.status) {
+        setStatus(stored.status);
+        statusRef.current = stored.status;
+      }
+    }
+    setSessionLoaded(true);
+  }, [loadStoredState]);
 
   const updateVars = useCallback(
     (newVars: Partial<WorkflowVars>) => {


### PR DESCRIPTION
## Summary
- avoid reading workflow state during server render
- hydrate workflow context from `localStorage` on mount

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855e3f8549c83228431eaf59948c0be