### PR TITLE
Add resource ID utilities and apply them

### DIFF
--- a/lib/info.ts
+++ b/lib/info.ts
@@ -8,6 +8,10 @@ import {
   TemplateId
 } from "@/constants";
 import { refreshTokenIfNeeded } from "@/lib/auth";
+import {
+  extractResourceId,
+  ResourceTypes
+} from "@/lib/workflow/utils/resource-ids";
 import { z } from "zod";
 
 export interface InfoItem {
@@ -132,9 +136,9 @@ export async function listSsoAssignments(): Promise<InfoItem[]> {
   const data = Schema.parse(await res.json());
   return (
     data.inboundSsoAssignments?.map((assignment) => {
-      const id = assignment.name.replace(
-        /^(?:.*\/)?inboundSsoAssignments\//,
-        ""
+      const id = extractResourceId(
+        assignment.name,
+        ResourceTypes.InboundSsoAssignments
       );
       return {
         id,

--- a/lib/workflow/info-actions.ts
+++ b/lib/workflow/info-actions.ts
@@ -9,6 +9,10 @@ import {
 } from "@/constants";
 import { env } from "@/env";
 import { refreshTokenIfNeeded } from "@/lib/auth";
+import {
+  extractResourceId,
+  ResourceTypes
+} from "@/lib/workflow/utils/resource-ids";
 import { z } from "zod";
 
 import pLimit from "p-limit";
@@ -116,7 +120,10 @@ export async function deleteSsoAssignments(
   ids: string[]
 ): Promise<DeleteResult> {
   return createGoogleDeleteAction((id) => {
-    const normalized = id.replace(/^(?:.*\/)?inboundSsoAssignments\//, "");
+    const normalized = extractResourceId(
+      id,
+      ResourceTypes.InboundSsoAssignments
+    );
     return `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(normalized)}`;
   }, "SSO Assignment")(ids);
 }

--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -4,6 +4,10 @@ import {
   isConflictError,
   isNotFoundError
 } from "@/lib/workflow/utils";
+import {
+  extractResourceId,
+  ResourceTypes
+} from "@/lib/workflow/utils/resource-ids";
 import type { WorkflowVars } from "@/types";
 import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
@@ -296,9 +300,9 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
       );
 
       if (rootAssignment) {
-        const id = rootAssignment.name.replace(
-          /^(?:.*\/)?inboundSsoAssignments\//,
-          ""
+        const id = extractResourceId(
+          rootAssignment.name,
+          ResourceTypes.InboundSsoAssignments
         );
         await google.delete(
           `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(id)}`,
@@ -312,9 +316,9 @@ export default defineStep<CheckData>(StepId.AssignUsersToSso)
       );
 
       if (automationAssignment) {
-        const id = automationAssignment.name.replace(
-          /^(?:.*\/)?inboundSsoAssignments\//,
-          ""
+        const id = extractResourceId(
+          automationAssignment.name,
+          ResourceTypes.InboundSsoAssignments
         );
         await google.delete(
           `${ApiEndpoint.Google.SsoAssignments}/${encodeURIComponent(id)}`,

--- a/lib/workflow/utils/resource-ids.ts
+++ b/lib/workflow/utils/resource-ids.ts
@@ -1,0 +1,52 @@
+/**
+ * Extracts resource ID from Google/Microsoft resource names
+ *
+ * Examples:
+ * - "inboundSsoAssignments/abc123" → "abc123"
+ * - "customers/C123/inboundSsoAssignments/abc123" → "abc123"
+ * - "abc123" → "abc123" (already extracted)
+ */
+export function extractResourceId(
+  resourceName: string,
+  resourceType: string
+): string {
+  // If it doesn't contain the resource type, assume it's already an ID
+  if (!resourceName.includes(resourceType)) {
+    return resourceName;
+  }
+
+  // Match everything after the last occurrence of resourceType/
+  const regex = new RegExp(`(?:.*\\/)?${resourceType}\\/(.*)`);
+  const match = resourceName.match(regex);
+  return match?.[1] || resourceName;
+}
+
+/**
+ * Common resource types
+ */
+export const ResourceTypes = {
+  // Google
+  InboundSsoAssignments: "inboundSsoAssignments",
+  InboundSamlSsoProfiles: "inboundSamlSsoProfiles",
+  OrgUnits: "orgUnits",
+  Roles: "roles",
+  RoleAssignments: "roleassignments",
+  Users: "users",
+
+  // Microsoft
+  ServicePrincipals: "servicePrincipals",
+  Applications: "applications",
+  SynchronizationJobs: "synchronization/jobs",
+  ClaimsMappingPolicies: "claimsMappingPolicies"
+} as const;
+
+/**
+ * Builds a resource name from components
+ */
+export function buildResourceName(
+  resourceType: string,
+  id: string,
+  prefix?: string
+): string {
+  return prefix ? `${prefix}/${resourceType}/${id}` : `${resourceType}/${id}`;
+}

--- a/test/utils/resource-ids.test.ts
+++ b/test/utils/resource-ids.test.ts
@@ -1,0 +1,60 @@
+import {
+  buildResourceName,
+  extractResourceId,
+  ResourceTypes
+} from "@/lib/workflow/utils/resource-ids";
+
+describe("Resource ID utilities", () => {
+  describe("extractResourceId", () => {
+    it("extracts ID from simple resource name", () => {
+      expect(
+        extractResourceId(
+          "inboundSsoAssignments/abc123",
+          ResourceTypes.InboundSsoAssignments
+        )
+      ).toBe("abc123");
+    });
+
+    it("extracts ID from nested resource name", () => {
+      expect(
+        extractResourceId(
+          "customers/C123/inboundSsoAssignments/abc123",
+          ResourceTypes.InboundSsoAssignments
+        )
+      ).toBe("abc123");
+    });
+
+    it("returns input if already an ID", () => {
+      expect(
+        extractResourceId("abc123", ResourceTypes.InboundSsoAssignments)
+      ).toBe("abc123");
+    });
+
+    it("handles IDs with special characters", () => {
+      expect(
+        extractResourceId(
+          "inboundSsoAssignments/abc-123_456",
+          ResourceTypes.InboundSsoAssignments
+        )
+      ).toBe("abc-123_456");
+    });
+  });
+
+  describe("buildResourceName", () => {
+    it("builds simple resource name", () => {
+      expect(
+        buildResourceName(ResourceTypes.InboundSsoAssignments, "abc123")
+      ).toBe("inboundSsoAssignments/abc123");
+    });
+
+    it("builds resource name with prefix", () => {
+      expect(
+        buildResourceName(
+          ResourceTypes.InboundSsoAssignments,
+          "abc123",
+          "customers/C123"
+        )
+      ).toBe("customers/C123/inboundSsoAssignments/abc123");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `extractResourceId` and `buildResourceName` helpers
- update Google SSO info functions to use the helper
- update workflow step and actions to normalize inbound SSO assignment IDs
- add unit tests for the new helpers

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855ea0dbc7483229ddc418a9c53ecf1