### PR TITLE
Add persisted state schema validation and ephemeral filtering

### DIFF
--- a/components/step-variables.tsx
+++ b/components/step-variables.tsx
@@ -89,6 +89,11 @@ export function StepVariables({ stepId, vars, onChange }: StepVariablesProps) {
           : <span className="italic text-slate-400 text-2xs">Not set</span>}
         </div>
       }
+      {meta.ephemeral && (
+        <div className="text-xs text-amber-600 mt-1">
+          ⚠️ This value is temporary and will be lost if you refresh the page
+        </div>
+      )}
     </div>
   );
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,8 +9,8 @@ const config: Config = {
     "^@/(.*)$": "<rootDir>/$1",
     "server-only": "<rootDir>/test/__mocks__/server-only.ts"
   },
-  extensionsToTreatAsEsm: [".ts"],
-  globals: { "ts-jest": { useESM: true } }
+  extensionsToTreatAsEsm: [".ts", ".tsx"],
+  globals: { "ts-jest": { useESM: true, tsconfig: "tsconfig.jest.json" } }
 };
 
 export default config;

--- a/lib/workflow/schemas/persisted-state.ts
+++ b/lib/workflow/schemas/persisted-state.ts
@@ -1,0 +1,99 @@
+import { WORKFLOW_VARIABLES } from "@/lib/workflow/variables";
+import { Var } from "@/types";
+import { z } from "zod";
+
+// Create a union of all valid Var values
+const VarSchema = z.enum([
+  Var.GoogleAccessToken,
+  Var.MsGraphToken,
+  Var.PrimaryDomain,
+  Var.IsDomainVerified,
+  Var.VerificationToken,
+  Var.AutomationOuName,
+  Var.AutomationOuPath,
+  Var.ProvisioningUserPrefix,
+  Var.AdminRoleName,
+  Var.SamlProfileDisplayName,
+  Var.ProvisioningAppDisplayName,
+  Var.SsoAppDisplayName,
+  Var.ClaimsPolicyDisplayName,
+  Var.ProvisioningUserId,
+  Var.ProvisioningUserEmail,
+  Var.GeneratedPassword,
+  Var.AdminRoleId,
+  Var.DirectoryServiceId,
+  Var.SsoServicePrincipalId,
+  Var.ProvisioningServicePrincipalId,
+  Var.SsoAppId,
+  Var.SamlProfileId,
+  Var.EntityId,
+  Var.AcsUrl,
+  Var.ClaimsPolicyId,
+  Var.MsSigningCertificate,
+  Var.MsSsoLoginUrl,
+  Var.MsSsoEntityId
+] as const);
+
+const StepStatusSchema = z.enum([
+  "idle",
+  "checking",
+  "executing",
+  "complete",
+  "failed",
+  "pending",
+  "undoing",
+  "reverted"
+]);
+
+const StepUIStateSchema = z.object({
+  status: StepStatusSchema,
+  summary: z.string().optional(),
+  error: z.string().optional(),
+  notes: z.string().optional()
+});
+
+// Schema for persisted workflow vars (filters out ephemeral ones)
+const PersistedVarsSchema = z
+  .record(VarSchema, z.string().optional())
+  .transform((vars) => {
+    // Filter out ephemeral variables during parsing
+    const filtered: Record<string, string | undefined> = {};
+    for (const [key, value] of Object.entries(vars)) {
+      if (
+        !WORKFLOW_VARIABLES[key as keyof typeof WORKFLOW_VARIABLES]?.ephemeral
+      ) {
+        filtered[key] = value;
+      }
+    }
+    return filtered;
+  });
+
+export const PersistedStateSchema = z.object({
+  vars: PersistedVarsSchema.optional(),
+  status: z.record(z.string(), StepUIStateSchema).optional()
+});
+
+export type PersistedState = z.infer<typeof PersistedStateSchema>;
+
+/**
+ * Safely parse persisted state with validation
+ */
+export function parsePersistedState(data: unknown): PersistedState | null {
+  try {
+    return PersistedStateSchema.parse(data);
+  } catch (error) {
+    console.error("Failed to parse persisted state:", error);
+    return null;
+  }
+}
+
+/**
+ * Prepare state for persistence (removes ephemeral vars)
+ */
+export function prepareStateForPersistence(
+  vars: Record<string, unknown>,
+  status: Record<string, unknown>
+): string {
+  const filtered = PersistedStateSchema.parse({ vars, status });
+  return JSON.stringify(filtered);
+}

--- a/test/workflow/ephemeral-vars.test.ts
+++ b/test/workflow/ephemeral-vars.test.ts
@@ -1,0 +1,18 @@
+import { filterEphemeralVars } from "@/components/workflow-context";
+import { Var } from "@/types";
+
+describe("Ephemeral variable filtering", () => {
+  it("should remove ephemeral variables from persistence", () => {
+    const vars = {
+      [Var.GeneratedPassword]: "secret123",
+      [Var.PrimaryDomain]: "example.com",
+      [Var.VerificationToken]: "token123"
+    } as const;
+
+    const filtered = filterEphemeralVars(vars);
+
+    expect(filtered[Var.GeneratedPassword]).toBeUndefined();
+    expect(filtered[Var.VerificationToken]).toBeUndefined();
+    expect(filtered[Var.PrimaryDomain]).toBe("example.com");
+  });
+});

--- a/test/workflow/persisted-state.test.ts
+++ b/test/workflow/persisted-state.test.ts
@@ -1,0 +1,60 @@
+import {
+  parsePersistedState,
+  prepareStateForPersistence
+} from "@/lib/workflow/schemas/persisted-state";
+import { Var } from "@/types";
+
+describe("Persisted state validation", () => {
+  it("should parse valid state", () => {
+    const input = {
+      vars: {
+        [Var.PrimaryDomain]: "example.com",
+        [Var.IsDomainVerified]: "true"
+      },
+      status: {
+        "verify-primary-domain": {
+          status: "complete",
+          summary: "Domain verified"
+        }
+      }
+    } as const;
+
+    const result = parsePersistedState(input);
+    expect(result).toEqual(input);
+  });
+
+  it("should filter out ephemeral variables", () => {
+    const input = {
+      vars: {
+        [Var.PrimaryDomain]: "example.com",
+        [Var.GeneratedPassword]: "secret123",
+        [Var.VerificationToken]: "token123"
+      },
+      status: {}
+    } as const;
+
+    const result = parsePersistedState(input);
+    expect(result?.vars).toEqual({ [Var.PrimaryDomain]: "example.com" });
+  });
+
+  it("should return null for invalid data", () => {
+    const invalid = { vars: { invalidVar: "value" } };
+
+    const result = parsePersistedState(invalid);
+    expect(result).toBeNull();
+  });
+
+  it("should prepare state for persistence", () => {
+    const vars = {
+      [Var.PrimaryDomain]: "example.com",
+      [Var.GeneratedPassword]: "secret123"
+    };
+    const status = {};
+
+    const json = prepareStateForPersistence(vars, status);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.vars[Var.GeneratedPassword]).toBeUndefined();
+    expect(parsed.vars[Var.PrimaryDomain]).toBe("example.com");
+  });
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- prevent persisting ephemeral variables
- validate workflow state from localStorage with zod
- warn when ephemeral values are shown in step variables
- enable ts-jest to handle TSX and JSX for tests
- test filtering of ephemeral vars and persisted state schema

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e9c240488322b0ff99a874261b87