### PR TITLE
Fix state reset effect loop

### DIFF
--- a/components/info-button.tsx
+++ b/components/info-button.tsx
@@ -90,7 +90,8 @@ export function InfoButton({
       setFailedDeletes(new Map());
       setDeleteConfirmText("");
     }
-  }, [open, resetSelection, resetPagination]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const handleDeleteSelected = async () => {
     if (!deleteItems || selectedIds.size === 0) return;

--- a/hooks/use-paginated-items.ts
+++ b/hooks/use-paginated-items.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 export function usePaginatedItems<T>(items: T[], itemsPerPage: number = 25) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -11,11 +11,30 @@ export function usePaginatedItems<T>(items: T[], itemsPerPage: number = 25) {
     return items.slice(start, end);
   }, [items, currentPage, itemsPerPage]);
 
-  const goToPage = (page: number) => {
-    setCurrentPage(Math.max(1, Math.min(page, totalPages)));
-  };
+  const goToPage = useCallback(
+    (page: number) => {
+      setCurrentPage(
+        Math.max(1, Math.min(page, Math.ceil(items.length / itemsPerPage)))
+      );
+    },
+    [items.length, itemsPerPage]
+  );
 
-  const reset = () => setCurrentPage(1);
+  const goToFirstPage = useCallback(() => goToPage(1), [goToPage]);
+  const goToLastPage = useCallback(
+    () => goToPage(totalPages),
+    [goToPage, totalPages]
+  );
+  const goToNextPage = useCallback(
+    () => goToPage(currentPage + 1),
+    [goToPage, currentPage]
+  );
+  const goToPrevPage = useCallback(
+    () => goToPage(currentPage - 1),
+    [goToPage, currentPage]
+  );
+
+  const reset = useCallback(() => setCurrentPage(1), []);
 
   return {
     currentPage,
@@ -24,10 +43,10 @@ export function usePaginatedItems<T>(items: T[], itemsPerPage: number = 25) {
     totalItems: items.length,
     itemsPerPage,
     goToPage,
-    goToFirstPage: () => goToPage(1),
-    goToLastPage: () => goToPage(totalPages),
-    goToNextPage: () => goToPage(currentPage + 1),
-    goToPrevPage: () => goToPage(currentPage - 1),
+    goToFirstPage,
+    goToLastPage,
+    goToNextPage,
+    goToPrevPage,
     reset
   };
 }


### PR DESCRIPTION
## Summary
- memoize pagination helpers with `useCallback`
- limit InfoButton cleanup effect to run only when `open` changes

## Testing
- `./scripts/token-info.sh`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `SKIP_E2E=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855fb3a77088322abfb5b6f437fe92c