### PR TITLE
Improve step card animations and info UI spacing

### DIFF
--- a/components/info/info-button.tsx
+++ b/components/info/info-button.tsx
@@ -16,7 +16,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
   DialogTrigger
 } from "@/components/ui/dialog";
@@ -151,15 +150,15 @@ export function InfoButton({
           <Info className="h-3.5 w-3.5" /> Inspect
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-2xl max-h-[600px] flex flex-col">
-        <DialogHeader>
+      <DialogContent className="max-w-2xl max-h-[600px] flex flex-col p-0">
+        <div className="px-6 py-4 border-b space-y-1">
           <DialogTitle>{title}</DialogTitle>
-          {context && <p className="text-xs text-slate-600 mt-1">{context}</p>}
-        </DialogHeader>
+          {context && <p className="text-xs text-slate-600">{context}</p>}
+        </div>
 
         {deleteItems && deletableItems.length > 0 && (
-          <div className="flex items-center justify-between gap-3 px-6 py-2 border-b">
-            <div className="flex items-center gap-3">
+          <div className="flex items-center justify-between gap-2 px-6 py-2 border-b">
+            <div className="flex items-center gap-2">
               {visibleDeletableItems.length > 0 && (
                 <Checkbox
                   checked={
@@ -242,7 +241,7 @@ export function InfoButton({
           </div>
         )}
 
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto px-6 py-4">
           {loading && <p className="text-sm text-slate-600 p-4">Loading...</p>}
           {error && <p className="text-sm text-destructive p-4">{error}</p>}
           {!loading && !error && (
@@ -258,7 +257,7 @@ export function InfoButton({
         </div>
 
         {showPagination && (
-          <div className="border-t pt-3">
+          <div className="border-t px-6 py-3">
             <div className="flex items-center justify-between">
               <span className="text-xs text-slate-600">
                 Showing {(currentPage - 1) * 25 + 1}-

--- a/components/info/info-item-list.tsx
+++ b/components/info/info-item-list.tsx
@@ -1,5 +1,6 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import { InfoItem } from "@/lib/info";
+import { cn } from "@/lib/utils";
 import { Lock } from "lucide-react";
 
 interface InfoItemListProps {
@@ -28,13 +29,14 @@ export function InfoItemList({
   }
 
   return (
-    <div className="space-y-1 py-2">
+    <div className="divide-y divide-slate-100">
       {items.map((item) => (
         <div
           key={item.id}
-          className={`flex items-center gap-2 px-2 py-1 hover:bg-slate-50 rounded ${
-            failedDeletes.has(item.id) ? "bg-destructive/10" : ""
-          }`}>
+          className={cn(
+            "flex items-start gap-2 px-2 py-1",
+            failedDeletes.has(item.id) && "bg-destructive/10"
+          )}>
           {showCheckboxes && item.deletable !== false && (
             <Checkbox
               checked={selectedIds.has(item.id)}

--- a/components/step-card/step-card.tsx
+++ b/components/step-card/step-card.tsx
@@ -4,6 +4,7 @@ import { StepCardContent } from "@/components/step-card/step-card-content";
 import { StepCardProvider } from "@/components/step-card/step-card-context";
 import { StepCardHeader } from "@/components/step-card/step-card-header";
 import { Card } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { STEP_STATE_CONFIG } from "@/lib/workflow/step-constants";
 import {
@@ -46,37 +47,39 @@ export const StepCard = memo(function StepCard({
 
   return (
     <StepCardProvider value={actions}>
-      <Card
-        className={cn(
-          "transition-all duration-300 ease-out bg-white shadow-none hover:shadow-md",
-          config.borderClass,
-          !isExpanded && "cursor-pointer"
-        )}
-        onClick={() => !isExpanded && setIsExpanded(true)}>
-        <StepCardHeader
-          index={index}
-          stepId={definition.id}
-          state={state}
-          executing={executing}
-          isExpanded={isExpanded}
-          onToggle={() => setIsExpanded(!isExpanded)}
-        />
-        {(executing || state?.status === "pending") && (
-          <div className="my-6 px-6">
-            <div className="relative h-1 bg-slate-200 overflow-hidden rounded">
-              <div className="absolute inset-0 bg-primary animate-indeterminate" />
-            </div>
-          </div>
-        )}
-        {isExpanded && (
-          <StepCardContent
-            definition={definition}
+      <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+        <Card
+          className={cn(
+            "transition-all duration-300 ease-out bg-white shadow-none hover:shadow-md",
+            config.borderClass,
+            !isExpanded && "cursor-pointer"
+          )}
+          onClick={() => !isExpanded && setIsExpanded(true)}>
+          <StepCardHeader
+            index={index}
+            stepId={definition.id}
             state={state}
-            vars={vars}
             executing={executing}
+            isExpanded={isExpanded}
+            onToggle={() => setIsExpanded(!isExpanded)}
           />
-        )}
-      </Card>
+          {(executing || state?.status === "pending") && (
+            <div className="my-6 px-6">
+              <div className="relative h-1 bg-slate-200 overflow-hidden rounded">
+                <div className="absolute inset-0 bg-primary animate-indeterminate" />
+              </div>
+            </div>
+          )}
+          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+            <StepCardContent
+              definition={definition}
+              state={state}
+              vars={vars}
+              executing={executing}
+            />
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
     </StepCardProvider>
   );
 });


### PR DESCRIPTION
## Summary
- animate step cards using `Collapsible`
- tighten layout in info dialog
- trim whitespace and use dividers in info item list

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68560059c8d483228df1f7fde159c972