### PR TITLE
Improve error logs for steps

### DIFF
--- a/components/step-card/step-log-item.tsx
+++ b/components/step-card/step-log-item.tsx
@@ -83,7 +83,7 @@ export function StepLogItem({ log }: StepLogItemProps) {
           <span className="flex-1 truncate text-slate-800">
             {log.method ? extractPath(log.url ?? "") : log.message}
           </span>
-          {log.data !== null && (
+          {log.data !== null && log.data !== undefined && (
             <ChevronRight
               className={cn(
                 "h-3 w-3 transition-transform",
@@ -93,11 +93,13 @@ export function StepLogItem({ log }: StepLogItemProps) {
           )}
         </div>
       </CollapsibleTrigger>
-      {log.data !== null && (
+      {log.data !== null && log.data !== undefined && (
         <CollapsibleContent className="px-4 py-2 data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
           <div className="bg-slate-800 text-slate-100 rounded border border-slate-700 max-h-60 overflow-y-auto">
             <pre className="p-2 whitespace-pre-wrap">
-              {JSON.stringify(log.data, null, 2)}
+              {typeof log.data === "string" ?
+                log.data
+              : JSON.stringify(log.data, null, 2)}
             </pre>
           </div>
         </CollapsibleContent>


### PR DESCRIPTION
## Summary
- capture variable snapshots when logging step errors
- stringify error objects and show them in logs
- handle string log data in step log item UI

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685877b794bc83229b407cf27529b7a3