### PR TITLE
Fix SSO assignment check for missing certificate

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -19,6 +19,8 @@ export const ApiEndpoint = {
       `https://cloudidentity.googleapis.com/v1/${profileId}`,
     SamlProfileCredentials: (profileId: string) =>
       `https://cloudidentity.googleapis.com/v1/${profileId}/idpCredentials:add`,
+    SamlProfileCredentialsList: (profileId: string) =>
+      `https://cloudidentity.googleapis.com/v1/${profileId}/idpCredentials`,
     SiteVerification: "https://www.googleapis.com/siteVerification/v1"
   },
   GoogleAuth: {

--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -137,6 +137,22 @@ export default defineStep(StepId.AssignUsersToSso)
           return;
         }
 
+        const CredsSchema = z.object({
+          idpCredentials: z.array(z.object({ name: z.string() })).optional()
+        });
+
+        const { idpCredentials = [] } = await google.get(
+          ApiEndpoint.Google.SamlProfileCredentialsList(profileId),
+          CredsSchema,
+          { flatten: "idpCredentials" }
+        );
+
+        if (idpCredentials.length === 0) {
+          log(LogLevel.Info, "SAML profile missing certificate");
+          markIncomplete("SAML profile missing certificate", {});
+          return;
+        }
+
         const { inboundSsoAssignments = [] } = await google.get(
           ApiEndpoint.Google.SsoAssignments,
           AssignSchema,


### PR DESCRIPTION
## Summary
- detect if Google SAML profile has no uploaded certificate before assigning users to SSO
- expose new API endpoint constant for listing SAML profile credentials

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `./scripts/token-info.sh`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68587a74e8e08322b167df397b049a43