### PR TITLE
Fix step log viewer scrolling and debug text

### DIFF
--- a/components/step-card/step-log-item.tsx
+++ b/components/step-card/step-log-item.tsx
@@ -81,7 +81,9 @@ export function StepLogItem({ log }: StepLogItemProps) {
           </span>
           <span className="text-[10px] text-slate-500">{time}</span>
           <span className="flex-1 truncate text-slate-800">
-            {log.method ? extractPath(log.url ?? "") : log.message}
+            {log.method ?
+              `${log.message}: ${extractPath(log.url ?? "")}`
+            : log.message}
           </span>
           {log.data !== null && log.data !== undefined && (
             <ChevronRight

--- a/components/step-card/step-logs.tsx
+++ b/components/step-card/step-logs.tsx
@@ -2,6 +2,7 @@
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { StepLogEntry } from "@/types";
+import { useEffect, useRef } from "react";
 import { StepLogItem } from "./step-log-item";
 
 interface StepLogsProps {
@@ -9,12 +10,28 @@ interface StepLogsProps {
 }
 
 export function StepLogs({ logs }: StepLogsProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const viewport = el.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    ) as HTMLDivElement | null;
+    if (viewport) {
+      viewport.scrollTop = viewport.scrollHeight;
+    }
+  }, [logs]);
+
   if (!logs || logs.length === 0) {
     return null;
   }
 
   return (
-    <ScrollArea className="max-h-64" onClick={(e) => e.stopPropagation()}>
+    <ScrollArea
+      ref={ref}
+      className="max-h-64 overflow-y-auto"
+      onClick={(e) => e.stopPropagation()}>
       <div className="divide-y">
         {logs.map((log, index) => (
           <StepLogItem key={index} log={log} />


### PR DESCRIPTION
## Summary
- auto-scroll to latest entry in `StepLogs`
- show message and path together for HTTP logs

## Testing
- `./scripts/token-info.sh`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68587a88b3108322a7758bf8ec399776