### PR TITLE
Fix unstable info box keys

### DIFF
--- a/components/info/info-item-list.tsx
+++ b/components/info/info-item-list.tsx
@@ -30,9 +30,9 @@ export function InfoItemList({
 
   return (
     <div className="divide-y divide-slate-100">
-      {items.map((item) => (
+      {items.map((item, idx) => (
         <div
-          key={item.id}
+          key={`${item.id}-${idx}`}
           className={cn(
             "flex items-start gap-2 px-2 py-1",
             failedDeletes.has(item.id) && "bg-destructive/10"


### PR DESCRIPTION
## Summary
- ensure the InfoItem list uses a stable key across rerenders

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68587dc23a7c8322b107f5a2d2493385