### PR TITLE
Fix delete path for Google SAML profiles

### DIFF
--- a/lib/workflow/info-actions.ts
+++ b/lib/workflow/info-actions.ts
@@ -111,7 +111,7 @@ export async function deleteOrgUnits(ids: string[]): Promise<DeleteResult> {
 
 export async function deleteSamlProfiles(ids: string[]): Promise<DeleteResult> {
   return createGoogleDeleteAction(
-    (id) => `${ApiEndpoint.Google.SsoProfiles}/${encodeURIComponent(id)}`,
+    (id) => ApiEndpoint.Google.SamlProfile(id),
     "SAML Profile"
   )(ids);
 }


### PR DESCRIPTION
## Summary
- use `ApiEndpoint.Google.SamlProfile` in delete action

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68587fb4487c8322bef53cce352e5739