### PR TITLE
Remove unused CheckData aliases

### DIFF
--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -23,9 +23,6 @@ interface HttpClient {
   ): Promise<R>;
 }
 
-// Empty object type - this step doesn't extract data during check phase
-type CheckData = Record<string, never>;
-
 async function getRootOrgUnitId(google: HttpClient) {
   const OrgUnitsSchema = z.object({
     organizationUnits: z

--- a/lib/workflow/steps/complete-google-sso-setup.ts
+++ b/lib/workflow/steps/complete-google-sso-setup.ts
@@ -3,9 +3,6 @@ import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
 import { defineStep } from "../step-builder";
 
-// Empty object type - this step doesn't extract data during check phase
-type CheckData = Record<string, never>;
-
 export default defineStep(StepId.CompleteGoogleSsoSetup)
   .requires(
     Var.GoogleAccessToken,

--- a/lib/workflow/steps/create-automation-ou.ts
+++ b/lib/workflow/steps/create-automation-ou.ts
@@ -6,9 +6,6 @@ import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
 import { defineStep } from "../step-builder";
 
-// Empty object type - this step doesn't extract data during check phase
-type CheckData = Record<string, never>;
-
 export default defineStep(StepId.CreateAutomationOU)
   .requires(
     Var.GoogleAccessToken,

--- a/lib/workflow/steps/setup-microsoft-provisioning.ts
+++ b/lib/workflow/steps/setup-microsoft-provisioning.ts
@@ -5,9 +5,6 @@ import { LogLevel, StepId, Var } from "@/types";
 import { z } from "zod";
 import { defineStep } from "../step-builder";
 
-// Empty object type - this step doesn't extract data during check phase
-type CheckData = Record<string, never>;
-
 export default defineStep(StepId.SetupMicrosoftProvisioning)
   .requires(
     Var.MsGraphToken,


### PR DESCRIPTION
## Summary
- eliminate unused `CheckData` type aliases in workflow steps

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685881e79184832283a045da5b1c10ea