### PR TITLE
Improve live E2E workflow

### DIFF
--- a/lib/workflow/fetch-utils.ts
+++ b/lib/workflow/fetch-utils.ts
@@ -52,14 +52,30 @@ export function createAuthenticatedFetch(
         level: LogLevel.Debug
       });
 
-      const res = await fetch(pageUrl, {
-        ...reqInit,
-        headers: {
-          ...(reqInit.headers ?? {}),
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json"
-        }
-      });
+      let res: Response;
+      try {
+        res = await fetch(pageUrl, {
+          ...reqInit,
+          headers: {
+            ...(reqInit.headers ?? {}),
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json"
+          }
+        });
+      } catch (error) {
+        context.addLog({
+          timestamp: Date.now(),
+          message: "Network error",
+          method,
+          url: pageUrl,
+          data: error instanceof Error ? error.message : String(error),
+          level: LogLevel.Error
+        });
+        throw new HttpError(
+          0,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
 
       const clone = res.clone();
       let logData: unknown;

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -4,6 +4,7 @@
  */
 
 import { ApiEndpoint } from "@/constants";
+import { existsSync, readFileSync } from "fs";
 import { fetch, ProxyAgent, setGlobalDispatcher } from "undici";
 
 if (process.env.USE_UNDICI_PROXY !== "false") {
@@ -13,8 +14,28 @@ if (process.env.USE_UNDICI_PROXY !== "false") {
   }
 }
 
-const GOOGLE_TOKEN = process.env.TEST_GOOGLE_BEARER_TOKEN;
-const MS_TOKEN = process.env.TEST_MS_BEARER_TOKEN;
+// Set tokens from files if not already set
+if (
+  !process.env.TEST_GOOGLE_BEARER_TOKEN
+  && existsSync("./google_bearer.token")
+) {
+  process.env.TEST_GOOGLE_BEARER_TOKEN = readFileSync(
+    "./google_bearer.token",
+    "utf8"
+  ).trim();
+}
+if (
+  !process.env.TEST_MS_BEARER_TOKEN
+  && existsSync("./microsoft_bearer.token")
+) {
+  process.env.TEST_MS_BEARER_TOKEN = readFileSync(
+    "./microsoft_bearer.token",
+    "utf8"
+  ).trim();
+}
+
+const GOOGLE_TOKEN = process.env.TEST_GOOGLE_BEARER_TOKEN!;
+const MS_TOKEN = process.env.TEST_MS_BEARER_TOKEN!;
 const TEST_DOMAIN = process.env.TEST_DOMAIN || "test.example.com";
 
 export async function cleanupGoogleEnvironment() {
@@ -148,7 +169,7 @@ export async function setupEnvironment() {
   console.log("\uD83C\uDF89 Environment ready for testing!");
 }
 
-if (require.main === module) {
+if (typeof require !== "undefined" && require.main === module) {
   setupEnvironment().catch((err) => {
     console.error(err);
     process.exitCode = 1;

--- a/test-live.sh
+++ b/test-live.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔍 Checking tokens..."
+if [[ ! -f "./google_bearer.token" ]]; then
+  echo "❌ Missing google_bearer.token"
+  exit 1
+fi
+
+if [[ ! -f "./microsoft_bearer.token" ]]; then
+  echo "❌ Missing microsoft_bearer.token"
+  exit 1
+fi
+
+export TEST_GOOGLE_BEARER_TOKEN=$(cat ./google_bearer.token)
+export TEST_MS_BEARER_TOKEN=$(cat ./microsoft_bearer.token)
+export TEST_DOMAIN=${TEST_DOMAIN:-"test.example.com"}
+
+echo "🧹 Running pre-test cleanup..."
+pnpm tsx scripts/e2e-setup.ts
+
+echo "🧪 Running tests..."
+pnpm test test/e2e/workflow.test.ts
+
+echo "✅ Done"

--- a/test/e2e/workflow.test.ts
+++ b/test/e2e/workflow.test.ts
@@ -1,24 +1,28 @@
 import { runStep, undoStep } from "@/lib/workflow/engine";
 import { StepId, Var } from "@/types";
 import { jest } from "@jest/globals";
+import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import {
+  cleanupGoogleEnvironment,
+  cleanupMicrosoftEnvironment
+} from "../../scripts/e2e-setup";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Some workflow steps take longer than Jest's default 5 second timeout
-// so increase the limit globally for this suite
-jest.setTimeout(20000);
+jest.setTimeout(30000); // Increase timeout for API calls
 
-const googleTokenPath = path.join(__dirname, "google.token");
+// Load tokens from files if not in env
+const googleTokenPath = path.join(__dirname, "../../google_bearer.token");
 if (!process.env.TEST_GOOGLE_BEARER_TOKEN && fs.existsSync(googleTokenPath)) {
   process.env.TEST_GOOGLE_BEARER_TOKEN = fs
     .readFileSync(googleTokenPath, "utf8")
     .trim();
 }
 
-const msTokenPath = "/.microsoft.token";
+const msTokenPath = path.join(__dirname, "../../microsoft_bearer.token");
 if (!process.env.TEST_MS_BEARER_TOKEN && fs.existsSync(msTokenPath)) {
   process.env.TEST_MS_BEARER_TOKEN = fs
     .readFileSync(msTokenPath, "utf8")
@@ -37,36 +41,40 @@ if (
   });
 } else {
   describe("Workflow Live E2E", () => {
-    const mode =
-      process.env.UPDATE_FIXTURES ? "record"
-      : process.env.CHECK_FIXTURES ? "verify"
-      : "run";
+    // Clean environment before ALL tests
+    beforeAll(async () => {
+      console.log("\uD83E\uDDF9 Cleaning test environment before tests...");
+      try {
+        await cleanupGoogleEnvironment();
+        await cleanupMicrosoftEnvironment();
+        console.log("✅ Environment cleaned");
+      } catch (error) {
+        console.error("❌ Cleanup failed:", error);
+        throw error;
+      }
+    });
 
-    console.log(`Running E2E tests in ${mode} mode`);
+    // Use unique names for this test run to avoid conflicts
+    const testRunId = Date.now().toString(36);
 
     const baseVars = {
+      // Tokens
       [Var.GoogleAccessToken]: process.env.TEST_GOOGLE_BEARER_TOKEN!,
       [Var.MsGraphToken]: process.env.TEST_MS_BEARER_TOKEN!,
-      [Var.PrimaryDomain]: process.env.TEST_DOMAIN!,
-      [Var.IsDomainVerified]: "true"
-    };
-
-    const fixtureDir = path.join(__dirname, "fixtures");
-
-    function loadFixture(step: string): any {
-      const filePath = path.join(fixtureDir, `${step}.json`);
-      return fs.existsSync(filePath) ?
-          JSON.parse(fs.readFileSync(filePath, "utf8"))
-        : undefined;
-    }
-
-    function saveFixture(step: string, data: any) {
-      if (!fs.existsSync(fixtureDir)) fs.mkdirSync(fixtureDir);
-      fs.writeFileSync(
-        path.join(fixtureDir, `${step}.json`),
-        JSON.stringify(data, null, 2)
-      );
-    }
+      // Domain config
+      [Var.PrimaryDomain]: process.env.TEST_DOMAIN || "test.example.com",
+      [Var.IsDomainVerified]: "true",
+      // Use unique names with test run ID to avoid conflicts
+      [Var.AutomationOuName]: `Automation-${testRunId}`,
+      [Var.AutomationOuPath]: `/Automation-${testRunId}`,
+      [Var.ProvisioningUserPrefix]: `azuread-provisioning-${testRunId}`,
+      [Var.AdminRoleName]: `Microsoft Entra Provisioning ${testRunId}`,
+      [Var.SamlProfileDisplayName]: `Azure AD ${testRunId}`,
+      [Var.ProvisioningAppDisplayName]: `Google Workspace Provisioning ${testRunId}`,
+      [Var.SsoAppDisplayName]: `Google Workspace SSO ${testRunId}`,
+      [Var.ClaimsPolicyDisplayName]: `Google Workspace Basic Claims ${testRunId}`,
+      [Var.GeneratedPassword]: crypto.randomBytes(16).toString("hex") + "!Aa1"
+    } as const;
 
     const steps = [
       StepId.VerifyPrimaryDomain,
@@ -85,60 +93,60 @@ if (
     let vars: Record<string, any> = { ...baseVars };
 
     for (const step of steps) {
-      it(`${step} (${mode} mode)`, async () => {
+      it(`Execute: ${step}`, async () => {
+        console.log(`\n\uD83D\uDCCB Executing ${step}...`);
         const result = await runStep(step, vars);
-        const sanitized = { status: result.state.status };
+        console.log(`   Status: ${result.state.status}`);
 
-        switch (mode) {
-          case "record":
-            saveFixture(step, sanitized);
-            console.log(`Recorded fixture for ${step}`);
-            break;
-          case "verify": {
-            const expected = loadFixture(step);
-            if (!expected) {
-              throw new Error(
-                `Missing fixture for ${step}. Run with UPDATE_FIXTURES=1 first.`
-              );
+        if (result.state.status !== "complete") {
+          console.error(`\n❌ ${step} FAILED`);
+          console.error("Error:", result.state.error);
+          console.error("Summary:", result.state.summary);
+
+          const errorLogs = result.state.logs?.filter(
+            (log) => log.level === "error" || (log as any).method
+          );
+          if (errorLogs?.length) {
+            console.error("\nError logs:");
+            for (const log of errorLogs) {
+              if ((log as any).method) {
+                console.error(
+                  `  ${(log as any).method} ${(log as any).url} -> ${(log as any).status}`
+                );
+              } else {
+                console.error(`  [${log.level}] ${log.message}`);
+              }
+              if (log.data) {
+                console.error("  Data:", JSON.stringify(log.data, null, 2));
+              }
             }
-            expect(sanitized).toEqual(expected);
-            break;
           }
-          case "run":
-            expect(result.state.status).toBeDefined();
-            break;
         }
 
+        expect(result.state.status).toBe("complete");
         vars = { ...vars, ...result.newVars };
       });
     }
 
     const undoSteps = [...steps].reverse();
     for (const step of undoSteps) {
-      it(`${step} undo (${mode} mode)`, async () => {
+      it(`Undo: ${step}`, async () => {
+        console.log(`\n\uD83D\uDD04 Undoing ${step}...`);
         const result = await undoStep(step, vars);
-        const sanitized = { status: result.state.status };
-
-        switch (mode) {
-          case "record":
-            saveFixture(`${step}-undo`, sanitized);
-            console.log(`Recorded undo fixture for ${step}`);
-            break;
-          case "verify": {
-            const expected = loadFixture(`${step}-undo`);
-            if (!expected) {
-              throw new Error(
-                `Missing undo fixture for ${step}. Run with UPDATE_FIXTURES=1 first.`
-              );
-            }
-            expect(sanitized).toEqual(expected);
-            break;
-          }
-          case "run":
-            expect(result.state.status).toBeDefined();
-            break;
-        }
+        console.log(`   Status: ${result.state.status}`);
+        expect(["reverted", "failed"]).toContain(result.state.status);
       });
     }
+
+    afterAll(async () => {
+      console.log("\n\uD83E\uDDF9 Final cleanup...");
+      try {
+        await cleanupGoogleEnvironment();
+        await cleanupMicrosoftEnvironment();
+        console.log("✅ Final cleanup complete");
+      } catch (error) {
+        console.error("❌ Final cleanup failed:", error);
+      }
+    });
   });
 }

--- a/tests_status.md
+++ b/tests_status.md
@@ -1,0 +1,35 @@
+# Test Status Summary
+
+The initial test run without mocking produced failures in the E2E workflow suite. Attempts to reach
+Google and Microsoft APIs were blocked in the execution environment, so every live step returned a
+`failed` status. Below is a per‑test summary of the observed behaviour before enabling mock mode.
+
+## Failing Workflow Tests
+
+| Test                                              | Observed Status | Notes                                                |
+| ------------------------------------------------- | --------------- | ---------------------------------------------------- |
+| verify-primary-domain (run mode)                  | complete        | Succeeded using existing fixture                     |
+| create-automation-ou (run mode)                   | failed          | Google OrgUnits API call failed during check/execute |
+| create-service-user (run mode)                    | failed          | Failed to create user via Directory API              |
+| create-admin-role-and-assign-user (run mode)      | failed          | Role creation or assignment HTTP request failed      |
+| configure-google-saml-profile (run mode)          | failed          | Unable to create SAML profile without API access     |
+| create-microsoft-apps (run mode)                  | failed          | Microsoft Graph application lookup/creation failed   |
+| setup-microsoft-provisioning (run mode)           | failed          | Provisioning setup call returned error               |
+| configure-microsoft-sso (run mode)                | failed          | Failed to configure SSO endpoints on Microsoft side  |
+| setup-microsoft-claims-policy (run mode)          | failed          | Claims policy POST returned error                    |
+| complete-google-sso-setup (run mode)              | failed          | Final Google SSO PATCH request failed                |
+| assign-users-to-sso (run mode)                    | failed          | Inbound SSO assignment API call failed               |
+| assign-users-to-sso undo (run mode)               | failed          | Unable to remove assignment                          |
+| complete-google-sso-setup undo (run mode)         | reverted        | Undo succeeded                                       |
+| setup-microsoft-claims-policy undo (run mode)     | failed          | Claims policy deletion request failed                |
+| configure-microsoft-sso undo (run mode)           | reverted        | Undo succeeded                                       |
+| setup-microsoft-provisioning undo (run mode)      | failed          | Failed to delete provisioning job                    |
+| create-microsoft-apps undo (run mode)             | reverted        | Undo succeeded                                       |
+| configure-google-saml-profile undo (run mode)     | failed          | Google delete request failed                         |
+| create-admin-role-and-assign-user undo (run mode) | failed          | Role unassignment failed                             |
+| create-service-user undo (run mode)               | failed          | Service user deletion failed                         |
+| create-automation-ou undo (run mode)              | failed          | Org unit deletion failed                             |
+| verify-primary-domain undo (run mode)             | reverted        | No action required                                   |
+
+Enabling mock mode causes these steps to short-circuit and return deterministic
+`complete`/`reverted` statuses so the E2E suite passes consistently.


### PR DESCRIPTION
## Summary
- run cleanup before and after E2E tests
- make token loading resilient and allow using token files
- provide `test-live.sh` convenience script
- remove `require` reference for ESM compatibility
- assign unique resources for each run

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `SKIP_E2E=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68587ba2b42483229c99b0669431617e