### PR TITLE
Fix E2E cleanup and HTTP error handling

### DIFF
--- a/lib/workflow/fetch-utils.ts
+++ b/lib/workflow/fetch-utils.ts
@@ -98,6 +98,7 @@ export function createAuthenticatedFetch(
       if (!res.ok) {
         let detail = res.statusText;
         let body: unknown;
+        const errorClone = res.clone();
         try {
           body = await res.json();
           const err = (body as { error?: { message?: string } }).error;
@@ -108,7 +109,7 @@ export function createAuthenticatedFetch(
           }
         } catch {
           try {
-            detail = await res.text();
+            detail = await errorClone.text();
           } catch {
             // ignore
           }

--- a/lib/workflow/steps/configure-google-saml-profile.ts
+++ b/lib/workflow/steps/configure-google-saml-profile.ts
@@ -48,6 +48,13 @@ export default defineStep(StepId.ConfigureGoogleSamlProfile)
           ProfilesSchema,
           { flatten: "inboundSamlSsoProfiles" }
         );
+
+        if (inboundSamlSsoProfiles.length > 90) {
+          log(
+            LogLevel.Warn,
+            `Found ${inboundSamlSsoProfiles.length} SAML profiles - nearing API limits`
+          );
+        }
         // Extract: samlProfileId = inboundSamlSsoProfiles[0]?.name
 
         if (inboundSamlSsoProfiles.length > 0) {

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -78,7 +78,7 @@ export async function cleanupGoogleEnvironment() {
     });
   }
 
-  // 4. Delete SAML profiles
+  // 4. Delete ALL test SAML profiles
   const samlRes = await fetch(ApiEndpoint.Google.SsoProfiles, {
     headers: { Authorization: `Bearer ${GOOGLE_TOKEN}` }
   });
@@ -86,11 +86,23 @@ export async function cleanupGoogleEnvironment() {
     inboundSamlSsoProfiles?: Array<{ name: string; displayName: string }>;
   };
   for (const profile of samlData.inboundSamlSsoProfiles || []) {
-    if (profile.displayName === "Azure AD") {
-      await fetch(ApiEndpoint.Google.SamlProfile(profile.name), {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${GOOGLE_TOKEN}` }
-      });
+    if (
+      profile.displayName?.includes("Test SAML")
+      || profile.displayName?.includes("Azure AD")
+      || profile.displayName?.includes("Entra ID")
+    ) {
+      try {
+        await fetch(ApiEndpoint.Google.SamlProfile(profile.name), {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${GOOGLE_TOKEN}` }
+        });
+        console.log(`🗑️ Deleted SAML profile: ${profile.displayName}`);
+      } catch (e) {
+        console.warn(
+          `⚠️ Failed to delete SAML profile ${profile.displayName}:`,
+          e
+        );
+      }
     }
   }
 

--- a/test/e2e/workflow.test.ts
+++ b/test/e2e/workflow.test.ts
@@ -44,13 +44,25 @@ if (
     // Clean environment before ALL tests
     beforeAll(async () => {
       console.log("\uD83E\uDDF9 Cleaning test environment before tests...");
-      try {
-        await cleanupGoogleEnvironment();
-        await cleanupMicrosoftEnvironment();
-        console.log("✅ Environment cleaned");
-      } catch (error) {
-        console.error("❌ Cleanup failed:", error);
-        throw error;
+
+      let retries = 3;
+      while (retries > 0) {
+        try {
+          await cleanupGoogleEnvironment();
+          await cleanupMicrosoftEnvironment();
+          console.log("✅ Environment cleaned");
+          break;
+        } catch (error) {
+          retries--;
+          if (retries === 0) {
+            console.error("❌ Cleanup failed after 3 attempts:", error);
+            throw error;
+          }
+          console.warn(
+            `⚠️ Cleanup attempt failed, retrying... (${retries} attempts left)`
+          );
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- fix double-read of HTTP response in fetch-utils
- purge all test SAML profiles in the Google cleanup script
- retry cleanup step in e2e workflow tests
- warn if too many SAML profiles exist during check

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `RUN_E2E=1 pnpm test` *(fails: Exceeded timeout of 30000 ms for a hook)*

------
https://chatgpt.com/codex/tasks/task_e_6858961979b483229574e6893728aea0