### PR TITLE
Fix assignUsersToSso check logic and resource ID parsing

### DIFF
--- a/lib/workflow/utils/resource-ids.ts
+++ b/lib/workflow/utils/resource-ids.ts
@@ -28,6 +28,7 @@ export const ResourceTypes = {
   // Google
   InboundSsoAssignments: "inboundSsoAssignments",
   InboundSamlSsoProfiles: "inboundSamlSsoProfiles",
+  OrgUnitId: "id",
   OrgUnits: "orgUnits",
   Roles: "roles",
   RoleAssignments: "roleassignments",


### PR DESCRIPTION
## Summary
- simplify the Assign Users to SSO step
- centralize Google ID extraction with new `ResourceTypes.OrgUnitId`
- use `extractResourceId` when resolving root org unit

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685895e7e648832284fcbdf824f0ed32