### PR TITLE
Fix listUsers API call

### DIFF
--- a/lib/info.ts
+++ b/lib/info.ts
@@ -281,9 +281,10 @@ export async function listUsers(): Promise<InfoItem[]> {
       .optional()
   });
 
-  const res = await fetch(`${ApiEndpoint.Google.Users}?maxResults=25`, {
-    headers: { Authorization: `Bearer ${token.accessToken}` }
-  });
+  const res = await fetch(
+    `${ApiEndpoint.Google.Users}?customer=my_customer&maxResults=25`,
+    { headers: { Authorization: `Bearer ${token.accessToken}` } }
+  );
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = Schema.parse(await res.json());
   return (


### PR DESCRIPTION
## Summary
- include `customer=my_customer` when listing users

## Testing
- `./scripts/token-info.sh`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `SKIP_E2E=1 pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6858964971a4832288ff959f2cc71012