### PR TITLE
Fix root OU lookup for SSO assignment

### DIFF
--- a/lib/workflow/steps/assign-users-to-sso.ts
+++ b/lib/workflow/steps/assign-users-to-sso.ts
@@ -37,7 +37,7 @@ async function getRootOrgUnitId(google: HttpClient) {
   });
 
   const { organizationUnits = [] } = await google.get(
-    `${ApiEndpoint.Google.OrgUnits}?type=children`,
+    `${ApiEndpoint.Google.OrgUnits}?orgUnitPath=%2F&type=allIncludingParent`,
     OrgUnitsSchema,
     { flatten: "organizationUnits" }
   );
@@ -46,7 +46,9 @@ async function getRootOrgUnitId(google: HttpClient) {
     throw new Error("No org units found");
   }
 
-  const id = organizationUnits[0].parentOrgUnitId ?? "";
+  const root = organizationUnits.find((ou) => ou.orgUnitPath === "/");
+  const id =
+    root ? root.orgUnitId : (organizationUnits[0].parentOrgUnitId ?? "");
   return extractResourceId(id, ResourceTypes.OrgUnitId);
 }
 


### PR DESCRIPTION
## Summary
- query org units with `orgUnitPath=/` and include parent to obtain the root OU
- fallback to root entry when extracting the orgUnitId

## Testing
- `./scripts/token-info.sh`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685899e119608322a89c7db47c746a30