### PR TITLE
Improve step prerequisites handling

### DIFF
--- a/components/step-card/step-card-header.tsx
+++ b/components/step-card/step-card-header.tsx
@@ -47,7 +47,9 @@ export function StepCardHeader({
     executing ? "Executing..."
     : state?.status === "checking" ? "Checking..."
     : state?.status === "undoing" ? "Undoing..."
-    : state?.summary || "Ready to execute";
+    : state?.status === "blocked" ? "Waiting for prerequisites"
+    : state?.status === "ready" ? "Ready to execute"
+    : state?.summary || "Initializing";
   const currentState = executing ? "executing" : state?.status || "idle";
   const config = STEP_STATE_CONFIG[currentState];
 
@@ -92,6 +94,10 @@ export function StepCardHeader({
             className={config.badge.className}>
             {executing ?
               "Executing"
+            : state?.status === "blocked" ?
+              "Blocked"
+            : state?.status === "ready" ?
+              "Ready"
             : state?.status ?
               state.status.charAt(0).toUpperCase() + state.status.slice(1)
             : "Idle"}

--- a/components/step-card/step-card.tsx
+++ b/components/step-card/step-card.tsx
@@ -50,11 +50,14 @@ export const StepCard = memo(function StepCard({
       <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
         <Card
           className={cn(
-            "transition-all duration-300 ease-out bg-white shadow-none hover:shadow-md",
+            "transition-all duration-300 ease-out bg-white shadow-none",
+            state?.status !== "blocked" && "hover:shadow-md",
             config.borderClass,
-            !isExpanded && "cursor-pointer"
+            !isExpanded && state?.status !== "blocked" && "cursor-pointer"
           )}
-          onClick={() => !isExpanded && setIsExpanded(true)}>
+          onClick={() =>
+            !isExpanded && state?.status !== "blocked" && setIsExpanded(true)
+          }>
           <StepCardHeader
             index={index}
             stepId={definition.id}

--- a/lib/workflow/step-constants.ts
+++ b/lib/workflow/step-constants.ts
@@ -8,6 +8,24 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-slate-600 text-white",
     borderClass: "border-slate-200 hover:border-slate-300"
   },
+  ready: {
+    badge: {
+      variant: "outline" as const,
+      className: "bg-green-50 text-green-700 border-green-200"
+    },
+    icon: null,
+    indicatorClass: "bg-green-600 text-white",
+    borderClass: "border-green-200 hover:border-green-300"
+  },
+  blocked: {
+    badge: {
+      variant: "outline" as const,
+      className: "bg-gray-50 text-gray-500 border-gray-200"
+    },
+    icon: null,
+    indicatorClass: "bg-gray-400 text-white",
+    borderClass: "border-gray-200"
+  },
   checking: {
     badge: {
       variant: "default" as const,

--- a/lib/workflow/utils/compute-effective-status.ts
+++ b/lib/workflow/utils/compute-effective-status.ts
@@ -1,0 +1,28 @@
+import { StepDefinition, StepUIState, VarName, WorkflowVars } from "@/types";
+
+export function computeEffectiveStatus(
+  step: StepDefinition,
+  currentState: StepUIState | undefined,
+  vars: Partial<WorkflowVars>
+): StepUIState["status"] {
+  if (
+    currentState?.status === "executing"
+    || currentState?.status === "checking"
+  ) {
+    return currentState.status;
+  }
+
+  const missingPrerequisites = step.requires.filter(
+    (varName: VarName) => vars[varName] === undefined
+  );
+
+  if (missingPrerequisites.length > 0) {
+    return "blocked";
+  }
+
+  if (currentState?.status && currentState.status !== "idle") {
+    return currentState.status;
+  }
+
+  return "ready";
+}

--- a/test/e2e/workflow.test.ts
+++ b/test/e2e/workflow.test.ts
@@ -5,6 +5,7 @@ import { jest } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import crypto from "node:crypto";
 import {
   cleanupGoogleEnvironment,
   cleanupMicrosoftEnvironment

--- a/types.ts
+++ b/types.ts
@@ -90,6 +90,8 @@ export interface StepUndoContext {
 export interface StepUIState {
   status:
     | "idle"
+    | "ready"
+    | "blocked"
     | "checking"
     | "executing"
     | "complete"


### PR DESCRIPTION
## Summary
- add `ready` and `blocked` states to `StepUIState`
- show visual config for new states
- compute effective step status based on prerequisites
- surface blocked/ready statuses in step cards
- fix type error in workflow e2e test

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test` *(fails: configure-google-saml-profile step)*

------
https://chatgpt.com/codex/tasks/task_e_68589d7c89008322bb1b462936371117