### PR TITLE
Fix Google SAML profile create schema

### DIFF
--- a/lib/workflow/steps/configure-google-saml-profile.ts
+++ b/lib/workflow/steps/configure-google-saml-profile.ts
@@ -97,7 +97,9 @@ export default defineStep(StepId.ConfigureGoogleSamlProfile)
      * { "error": { "code": 400, "message": "Invalid request" } }
      */
     try {
-      const CreateSchema = z.object({
+      const CreateSchema = z.object({ name: z.string() });
+
+      const ProfileSchema = z.object({
         name: z.string(),
         spConfig: z.object({
           entityId: z.string(),
@@ -139,12 +141,17 @@ export default defineStep(StepId.ConfigureGoogleSamlProfile)
         return;
       }
 
-      const profile = op.response;
+      const profileName = op.response?.name;
 
-      if (!profile) {
+      if (!profileName) {
         markFailed("Missing profile in response");
         return;
       }
+
+      const profile = await google.get(
+        ApiEndpoint.Google.SamlProfile(profileName),
+        ProfileSchema
+      );
 
       output({
         samlProfileId: profile.name,

--- a/test/e2e/workflow.test.ts
+++ b/test/e2e/workflow.test.ts
@@ -1,5 +1,6 @@
 import { runStep, undoStep } from "@/lib/workflow/engine";
 import { generateSecurePassword } from "@/lib/workflow/utils/password";
+import { randomBytes } from "crypto";
 import { StepId, Var } from "@/types";
 import { jest } from "@jest/globals";
 import fs from "fs";
@@ -86,7 +87,7 @@ if (
       [Var.ProvisioningAppDisplayName]: `Test Google Workspace Provisioning ${testRunId}`,
       [Var.SsoAppDisplayName]: `Test Google Workspace SSO ${testRunId}`,
       [Var.ClaimsPolicyDisplayName]: `Test Google Workspace Basic Claims ${testRunId}`,
-      [Var.GeneratedPassword]: crypto.randomBytes(16).toString("hex") + "!Aa1"
+      [Var.GeneratedPassword]: randomBytes(16).toString("hex") + "!Aa1"
     } as const;
 
     const steps = [


### PR DESCRIPTION
## Summary
- update create schema for Google SAML profile creation
- fetch profile details after create
- fix e2e workflow test randomBytes import

## Testing
- `./scripts/token-info.sh`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `curl -i -s -X POST https://cloudidentity.googleapis.com/v1/customers/my_customer/inboundSamlSsoProfiles -H 'Authorization: Bearer $GOOGLE_TOKEN' -H 'Content-Type: application/json' -d '{"displayName":"Test","idpConfig":{"entityId":"","singleSignOnServiceUri":""}}' | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68589e4a25208322bd4bcd484a1d1e92