### PR TITLE
Refactor status and HTTP constants

### DIFF
--- a/components/step-card/step-api-calls.tsx
+++ b/components/step-card/step-api-calls.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import { API_PREFIXES, ApiEndpoint } from "@/constants";
 import { extractPath } from "@/lib/utils/url";
+import { HttpMethod } from "@/lib/workflow/http-constants";
 import { Var } from "@/types";
 
 type StepIdValue = string;
@@ -54,10 +55,11 @@ export function StepApiCalls({ stepId }: StepApiCallsProps) {
 
   const getMethodBadge = (method: string) => {
     const colors = {
-      GET: "bg-primary/10 text-primary border-primary/20",
-      POST: "bg-secondary/10 text-secondary border-secondary/20",
-      PUT: "bg-chart-1/10 text-chart-1 border-chart-1/20",
-      DELETE: "bg-destructive/10 text-destructive border-destructive/20"
+      [HttpMethod.GET]: "bg-primary/10 text-primary border-primary/20",
+      [HttpMethod.POST]: "bg-secondary/10 text-secondary border-secondary/20",
+      [HttpMethod.PUT]: "bg-chart-1/10 text-chart-1 border-chart-1/20",
+      [HttpMethod.DELETE]:
+        "bg-destructive/10 text-destructive border-destructive/20"
     } as const;
 
     return (

--- a/components/step-card/step-card-header.tsx
+++ b/components/step-card/step-card-header.tsx
@@ -5,6 +5,7 @@ import { CardHeader } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { STEP_STATE_CONFIG } from "@/lib/workflow/step-constants";
 import { STEP_DETAILS } from "@/lib/workflow/step-details";
+import { StepStatus } from "@/lib/workflow/step-status";
 import { StepIdValue, StepUIState } from "@/types";
 import {
   AlertTriangle,
@@ -45,12 +46,13 @@ export function StepCardHeader({
       .join(" ");
   const descriptor =
     executing ? "Executing..."
-    : state?.status === "checking" ? "Checking..."
-    : state?.status === "undoing" ? "Undoing..."
-    : state?.status === "blocked" ? "Waiting for prerequisites"
-    : state?.status === "ready" ? "Ready to execute"
+    : state?.status === StepStatus.Checking ? "Checking..."
+    : state?.status === StepStatus.Undoing ? "Undoing..."
+    : state?.status === StepStatus.Blocked ? "Waiting for prerequisites"
+    : state?.status === StepStatus.Ready ? "Ready to execute"
     : state?.summary || "Initializing";
-  const currentState = executing ? "executing" : state?.status || "idle";
+  const currentState =
+    executing ? StepStatus.Executing : state?.status || StepStatus.Idle;
   const config = STEP_STATE_CONFIG[currentState];
 
   const Icon =

--- a/constants.ts
+++ b/constants.ts
@@ -1,3 +1,5 @@
+import { TIME } from "@/lib/workflow/constants/workflow-limits";
+
 export const ApiEndpoint = {
   Google: {
     Domains:
@@ -100,14 +102,10 @@ export type Provider = (typeof PROVIDERS)[keyof typeof PROVIDERS];
 
 export const OAUTH_STATE_COOKIE_NAME = "oauth_state";
 
-const MINUTE = 60;
-const HOUR = MINUTE * 60;
-const DAY = HOUR * 24;
-
 export const WORKFLOW_CONSTANTS = {
-  TOKEN_COOKIE_MAX_AGE: DAY * 7,
-  OAUTH_STATE_TTL_MS: 10 * MINUTE * 1000,
-  TOKEN_REFRESH_BUFFER_MS: 5 * MINUTE * 1000
+  TOKEN_COOKIE_MAX_AGE: TIME.DAY * 7,
+  OAUTH_STATE_TTL_MS: 10 * TIME.MINUTE,
+  TOKEN_REFRESH_BUFFER_MS: 5 * TIME.MINUTE
 };
 
 export const API_PREFIXES = {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -6,6 +6,7 @@ import {
   WORKFLOW_CONSTANTS
 } from "@/constants";
 import { env } from "@/env";
+import { TIME } from "@/lib/workflow/constants/workflow-limits";
 import {
   createCipheriv,
   createDecipheriv,
@@ -122,8 +123,6 @@ const microsoftOAuthConfig: OAuthConfig = {
   ]
 };
 
-const MS_IN_SECOND = 1000;
-
 function getOAuthConfig(provider: Provider): OAuthConfig {
   return provider === PROVIDERS.GOOGLE ?
       googleOAuthConfig
@@ -193,7 +192,7 @@ export async function exchangeCodeForToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token,
-    expiresAt: Date.now() + data.expires_in * MS_IN_SECOND,
+    expiresAt: Date.now() + data.expires_in * TIME.MS_IN_SECOND,
     scope: data.scope?.split(" ") || config.scopes
   };
 }
@@ -251,7 +250,7 @@ export async function refreshTokenIfNeeded(
     const newToken: Token = {
       accessToken: data.access_token,
       refreshToken: data.refresh_token || token.refreshToken,
-      expiresAt: Date.now() + data.expires_in * MS_IN_SECOND,
+      expiresAt: Date.now() + data.expires_in * TIME.MS_IN_SECOND,
       scope: data.scope?.split(" ") || token.scope
     };
 

--- a/lib/workflow/constants/workflow-limits.ts
+++ b/lib/workflow/constants/workflow-limits.ts
@@ -7,6 +7,7 @@ export const WORKFLOW_LIMITS = {
 } as const;
 
 export const TIME = {
+  MS_IN_SECOND: 1000,
   SECOND: 1000,
   MINUTE: 60 * 1000,
   HOUR: 60 * 60 * 1000,

--- a/lib/workflow/errors.ts
+++ b/lib/workflow/errors.ts
@@ -1,3 +1,5 @@
+import { HttpStatus } from "./http-constants";
+
 export class HttpError extends Error {
   constructor(
     public statusCode: number,
@@ -11,21 +13,21 @@ export class HttpError extends Error {
 
 export class NotFoundError extends HttpError {
   constructor(message = "Resource not found", responseBody?: unknown) {
-    super(404, message, responseBody);
+    super(HttpStatus.NotFound, message, responseBody);
     this.name = "NotFoundError";
   }
 }
 
 export class ConflictError extends HttpError {
   constructor(message = "Resource conflict", responseBody?: unknown) {
-    super(409, message, responseBody);
+    super(HttpStatus.Conflict, message, responseBody);
     this.name = "ConflictError";
   }
 }
 
 export class PreconditionFailedError extends HttpError {
   constructor(message = "Precondition failed", responseBody?: unknown) {
-    super(412, message, responseBody);
+    super(HttpStatus.PreconditionFailed, message, responseBody);
     this.name = "PreconditionFailedError";
   }
 }
@@ -39,15 +41,22 @@ export function isHttpError(
 }
 
 export function isNotFoundError(error: unknown): error is NotFoundError {
-  return error instanceof NotFoundError || isHttpError(error, 404);
+  return (
+    error instanceof NotFoundError || isHttpError(error, HttpStatus.NotFound)
+  );
 }
 
 export function isConflictError(error: unknown): error is ConflictError {
-  return error instanceof ConflictError || isHttpError(error, 409);
+  return (
+    error instanceof ConflictError || isHttpError(error, HttpStatus.Conflict)
+  );
 }
 
 export function isPreconditionFailedError(
   error: unknown
 ): error is PreconditionFailedError {
-  return error instanceof PreconditionFailedError || isHttpError(error, 412);
+  return (
+    error instanceof PreconditionFailedError
+    || isHttpError(error, HttpStatus.PreconditionFailed)
+  );
 }

--- a/lib/workflow/fetch-utils.ts
+++ b/lib/workflow/fetch-utils.ts
@@ -6,6 +6,7 @@ import {
   NotFoundError,
   PreconditionFailedError
 } from "./errors";
+import { HttpMethod, HttpStatus } from "./http-constants";
 import { detectLRO, type LROMetadata } from "./lro-detector";
 
 export type FetchOpts = RequestInit & { flatten?: boolean | string };
@@ -29,7 +30,7 @@ export function createAuthenticatedFetch(
     const { flatten, ...reqInit } = (init as FetchOpts) ?? {};
 
     const fetchPage = async (pageUrl: string): Promise<T> => {
-      const method = reqInit.method ?? "GET";
+      const method = reqInit.method ?? HttpMethod.GET;
       const body = reqInit.body;
       let parsedBody: unknown;
       if (body) {
@@ -118,11 +119,11 @@ export function createAuthenticatedFetch(
         }
 
         switch (res.status) {
-          case 404:
+          case HttpStatus.NotFound:
             throw new NotFoundError(detail, body);
-          case 409:
+          case HttpStatus.Conflict:
             throw new ConflictError(detail, body);
-          case 412:
+          case HttpStatus.PreconditionFailed:
             throw new PreconditionFailedError(detail, body);
           default:
             throw new HttpError(res.status, detail, body);

--- a/lib/workflow/http-constants.ts
+++ b/lib/workflow/http-constants.ts
@@ -1,0 +1,22 @@
+export enum HttpMethod {
+  GET = "GET",
+  POST = "POST",
+  PUT = "PUT",
+  PATCH = "PATCH",
+  DELETE = "DELETE"
+}
+
+export enum HttpStatus {
+  OK = 200,
+  Created = 201,
+  NoContent = 204,
+  BadRequest = 400,
+  Unauthorized = 401,
+  Forbidden = 403,
+  NotFound = 404,
+  Conflict = 409,
+  PreconditionFailed = 412
+}
+
+export type HttpMethodValue = `${HttpMethod}`;
+export type HttpStatusCode = number;

--- a/lib/workflow/schemas/persisted-state.ts
+++ b/lib/workflow/schemas/persisted-state.ts
@@ -1,6 +1,7 @@
 import { WORKFLOW_VARIABLES } from "@/lib/workflow/variables";
 import { Var } from "@/types";
 import { z } from "zod";
+import { StepStatus } from "../step-status";
 
 // Create a union of all valid Var values
 const VarSchema = z.enum([
@@ -34,16 +35,7 @@ const VarSchema = z.enum([
   Var.MsSsoEntityId
 ] as const);
 
-const StepStatusSchema = z.enum([
-  "idle",
-  "checking",
-  "executing",
-  "complete",
-  "failed",
-  "pending",
-  "undoing",
-  "reverted"
-]);
+const StepStatusSchema = z.nativeEnum(StepStatus);
 
 const StepUIStateSchema = z.object({
   status: StepStatusSchema,

--- a/lib/workflow/step-builder.ts
+++ b/lib/workflow/step-builder.ts
@@ -9,6 +9,7 @@ import {
 } from "@/types";
 import { z } from "zod";
 import { createStep } from "./create-step";
+import { HttpMethod } from "./http-constants";
 import type { HttpClient } from "./types/http-client";
 import { createVarStore, type BasicVarStore } from "./var-store";
 
@@ -147,31 +148,31 @@ function createHttpClient(
 ): HttpClient {
   return {
     get: (url, schema, options) =>
-      fetchFn(url, schema, { method: "GET", ...options }),
+      fetchFn(url, schema, { method: HttpMethod.GET, ...options }),
 
     post: (url, schema, body, options) =>
       fetchFn(url, schema, {
-        method: "POST",
+        method: HttpMethod.POST,
         body: body ? JSON.stringify(body) : undefined,
         ...options
       }),
 
     put: (url, schema, body, options) =>
       fetchFn(url, schema, {
-        method: "PUT",
+        method: HttpMethod.PUT,
         body: body ? JSON.stringify(body) : undefined,
         ...options
       }),
 
     patch: (url, schema, body, options) =>
       fetchFn(url, schema, {
-        method: "PATCH",
+        method: HttpMethod.PATCH,
         body: body ? JSON.stringify(body) : undefined,
         ...options
       }),
 
     delete: (url, schema, options) =>
-      fetchFn(url, schema, { method: "DELETE", ...options })
+      fetchFn(url, schema, { method: HttpMethod.DELETE, ...options })
   };
 }
 

--- a/lib/workflow/step-constants.ts
+++ b/lib/workflow/step-constants.ts
@@ -1,5 +1,7 @@
+import { StepStatus } from "./step-status";
+
 export const STEP_STATE_CONFIG = {
-  idle: {
+  [StepStatus.Idle]: {
     badge: {
       variant: "outline" as const,
       className: "bg-slate-100 text-slate-600 border-slate-200"
@@ -8,7 +10,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-slate-600 text-white",
     borderClass: "border-slate-200 hover:border-slate-300"
   },
-  ready: {
+  [StepStatus.Ready]: {
     badge: {
       variant: "outline" as const,
       className: "bg-green-50 text-green-700 border-green-200"
@@ -17,7 +19,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-green-600 text-white",
     borderClass: "border-green-200 hover:border-green-300"
   },
-  blocked: {
+  [StepStatus.Blocked]: {
     badge: {
       variant: "outline" as const,
       className: "bg-gray-50 text-gray-500 border-gray-200"
@@ -26,7 +28,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-gray-400 text-white",
     borderClass: "border-gray-200"
   },
-  checking: {
+  [StepStatus.Checking]: {
     badge: {
       variant: "default" as const,
       className: "bg-primary/10 text-primary border-primary/20"
@@ -35,7 +37,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-primary text-white animate-breathing",
     borderClass: "border-primary/30"
   },
-  executing: {
+  [StepStatus.Executing]: {
     badge: {
       variant: "default" as const,
       className: "bg-primary/10 text-primary border-primary/20"
@@ -44,7 +46,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-primary text-white animate-breathing",
     borderClass: "border-primary ring-1 ring-primary/30"
   },
-  complete: {
+  [StepStatus.Complete]: {
     badge: {
       variant: "default" as const,
       className: "bg-secondary/10 text-secondary border-secondary/20"
@@ -53,7 +55,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-secondary text-white",
     borderClass: "border-secondary"
   },
-  failed: {
+  [StepStatus.Failed]: {
     badge: {
       variant: "destructive" as const,
       className: "bg-destructive/10 text-destructive border-destructive/20"
@@ -62,7 +64,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-destructive text-white",
     borderClass: "border-destructive"
   },
-  pending: {
+  [StepStatus.Pending]: {
     badge: {
       variant: "default" as const,
       className: "bg-chart-1/10 text-chart-1 border-chart-1/20"
@@ -71,7 +73,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-chart-1 text-white",
     borderClass: "border-chart-1"
   },
-  undoing: {
+  [StepStatus.Undoing]: {
     badge: {
       variant: "default" as const,
       className: "bg-chart-1/10 text-chart-1 border-chart-1/20"
@@ -80,7 +82,7 @@ export const STEP_STATE_CONFIG = {
     indicatorClass: "bg-chart-1 text-white animate-breathing",
     borderClass: "border-chart-1 ring-1 ring-chart-1/30"
   },
-  reverted: {
+  [StepStatus.Reverted]: {
     badge: {
       variant: "outline" as const,
       className: "bg-slate-100 text-slate-700 border-slate-200"

--- a/lib/workflow/step-status.ts
+++ b/lib/workflow/step-status.ts
@@ -1,0 +1,14 @@
+export enum StepStatus {
+  Idle = "idle",
+  Ready = "ready",
+  Blocked = "blocked",
+  Checking = "checking",
+  Executing = "executing",
+  Complete = "complete",
+  Failed = "failed",
+  Pending = "pending",
+  Undoing = "undoing",
+  Reverted = "reverted"
+}
+
+export type StepStatusValue = `${StepStatus}`;

--- a/lib/workflow/utils/compute-effective-status.ts
+++ b/lib/workflow/utils/compute-effective-status.ts
@@ -1,13 +1,15 @@
 import { StepDefinition, StepUIState, VarName, WorkflowVars } from "@/types";
+import type { StepStatusValue } from "../step-status";
+import { StepStatus } from "../step-status";
 
 export function computeEffectiveStatus(
   step: StepDefinition,
   currentState: StepUIState | undefined,
   vars: Partial<WorkflowVars>
-): StepUIState["status"] {
+): StepStatusValue {
   if (
-    currentState?.status === "executing"
-    || currentState?.status === "checking"
+    currentState?.status === StepStatus.Executing
+    || currentState?.status === StepStatus.Checking
   ) {
     return currentState.status;
   }
@@ -17,12 +19,12 @@ export function computeEffectiveStatus(
   );
 
   if (missingPrerequisites.length > 0) {
-    return "blocked";
+    return StepStatus.Blocked;
   }
 
-  if (currentState?.status && currentState.status !== "idle") {
+  if (currentState?.status && currentState.status !== StepStatus.Idle) {
     return currentState.status;
   }
 
-  return "ready";
+  return StepStatus.Ready;
 }

--- a/test/e2e/workflow.test.ts
+++ b/test/e2e/workflow.test.ts
@@ -1,12 +1,11 @@
 import { runStep, undoStep } from "@/lib/workflow/engine";
 import { generateSecurePassword } from "@/lib/workflow/utils/password";
-import { randomBytes } from "crypto";
 import { StepId, Var } from "@/types";
 import { jest } from "@jest/globals";
+import { randomBytes } from "crypto";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import crypto from "node:crypto";
 
 import {
   cleanupGoogleEnvironment,

--- a/types.ts
+++ b/types.ts
@@ -87,18 +87,10 @@ export interface StepUndoContext {
   markFailed(error: string): void;
 }
 
+import type { StepStatusValue } from "./lib/workflow/step-status";
+
 export interface StepUIState {
-  status:
-    | "idle"
-    | "ready"
-    | "blocked"
-    | "checking"
-    | "executing"
-    | "complete"
-    | "failed"
-    | "pending"
-    | "undoing"
-    | "reverted";
+  status: StepStatusValue;
   summary?: string;
   error?: string;
   notes?: string;


### PR DESCRIPTION
## Summary
- introduce StepStatus enum and update workflow code
- add HTTP constants and use them across helpers
- consolidate time constants in workflow limits
- reference time constants in auth and global constants
- refresh lint and tests

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6858a50a56f08322814731b5ae75a9f3