### PR TITLE
Fix admin role undo step

### DIFF
--- a/lib/workflow/steps/create-admin-role-and-assign-user.ts
+++ b/lib/workflow/steps/create-admin-role-and-assign-user.ts
@@ -326,12 +326,23 @@ export default defineStep(StepId.CreateAdminRoleAndAssignUser)
             .optional()
         });
 
-        const { items = [] } = await google.get(
-          `${ApiEndpoint.Google.RoleAssignments}?roleId=${encodeURIComponent(roleId)}`,
+        const queryUrl =
+          userId ?
+            `${ApiEndpoint.Google.RoleAssignments}?userKey=${encodeURIComponent(userId)}`
+          : `${ApiEndpoint.Google.RoleAssignments}?roleId=${encodeURIComponent(roleId)}`;
+
+        const { items: assignments = [] } = await google.get(
+          queryUrl,
           AllAssignSchema
         );
 
-        for (const assignment of items) {
+        const toRemove = assignments.filter(
+          (assignment) =>
+            assignment.roleId === roleId
+            && (!userId || assignment.assignedTo === userId)
+        );
+
+        for (const assignment of toRemove) {
           try {
             await google.delete(
               `${ApiEndpoint.Google.RoleAssignments}/${assignment.roleAssignmentId}`,


### PR DESCRIPTION
## Summary
- ensure undo step queries role assignments using userKey

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test` *(fails: Import attributes are only supported when the `--module` option is set to 'esnext', 'node18', 'nodenext', or 'preserve')*

------
https://chatgpt.com/codex/tasks/task_e_6858a8bd27648322ad5a7564627f780d