### PR TITLE
Fix check step logs retrieval

### DIFF
--- a/components/workflow-context.tsx
+++ b/components/workflow-context.tsx
@@ -289,9 +289,10 @@ export function WorkflowProvider({
 
   const checkSteps = useCallback(async () => {
     for (const step of steps) {
+      const current = status[step.id];
       if (
         checkedSteps.current.has(step.id)
-        || status[step.id]?.status === StepStatus.Complete
+        || (current?.status === StepStatus.Complete && current.logs?.length)
       ) {
         continue;
       }


### PR DESCRIPTION
## Summary
- re-run checks for completed steps that lack logs so execution history loads on refresh

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test` *(fails: Unable to compile TypeScript due to import.meta in Jest config)*

------
https://chatgpt.com/codex/tasks/task_e_6858aebfff448322ac40807bc5ced3ac