### PR TITLE
Fix duplicate key warning in StepApiCalls

### DIFF
--- a/components/step-card/step-api-calls.tsx
+++ b/components/step-card/step-api-calls.tsx
@@ -77,8 +77,8 @@ export function StepApiCalls({ stepId }: StepApiCallsProps) {
   return (
     <TooltipProvider>
       <div className="space-y-1 text-xs" onClick={(e) => e.stopPropagation()}>
-        {apiTemplates.map((template) => (
-          <Tooltip key={`${template.method}-${template.endpoint}`}>
+        {apiTemplates.map((template, index) => (
+          <Tooltip key={`${template.method}-${template.endpoint}-${index}`}>
             <TooltipTrigger asChild>
               <div className="flex items-center gap-3 rounded py-2 hover:bg-slate-100 cursor-pointer">
                 <div className="flex-shrink-0">


### PR DESCRIPTION
## Summary
- ensure StepApiCalls uses a unique React key for each tooltip

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `SKIP_E2E=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b5815fb88322bc16457ee13d3965